### PR TITLE
#2 install libpng-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM circleci/php:7.2-cli-node
 
+# Install libpng-dev required by some frontend libs
+RUN apt-get update && apt-get install -y libpng-dev
+
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
 


### PR DESCRIPTION
Better to have this in the base image then doing that in all circle-ci configs