### PR TITLE
SLT-152: Add scripts with release naming and cluster access setup logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,7 @@ RUN curl -o /tmp/$FILENAME ${HELM_URL} \
 # Add custom php config. Increase memory to 256M
 COPY conf/php/memory.ini /usr/local/etc/php/conf.d/memory.ini
 
+# Add custom scripts for use during build
+COPY utils /home/circleci/utils
+RUN sudo chmod -R 755 /home/circleci/utils
+

--- a/utils/gcloud_init.sh
+++ b/utils/gcloud_init.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Save key, authenticate and set compute zone
+echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
+gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json --project $GCLOUD_PROJECT_NAME
+gcloud config set compute/zone $GCLOUD_COMPUTE_ZONE
+
+# Updates a kubeconfig file with appropriate credentials and endpoint information 
+# to point kubectl at a specific cluster in Google Kubernetes Engine
+gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME \
+	  --zone $GCLOUD_COMPUTE_ZONE \
+	    --project $GCLOUD_PROJECT_NAME

--- a/utils/set_release_name.sh
+++ b/utils/set_release_name.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Custom release naming convention for SILTA
+# Set the release name in circleci for later reuse.
+
+# Release name length is 37 chars long, which leaves max 16 chars for kubernetes resource name.
+# Release name is prefixed with w because  it _HAS_ to start with alphabetic character. w 4 wunder.
+
+LOWERCASE_BRANCH=${CIRCLE_BRANCH,,}
+REPONAME_HASH=$(echo ${CIRCLE_PROJECT_REPONAME,,} | shasum -a 256 | cut -c 1-8 )
+BRANCHNAME_HASH=$(echo $LOWERCASE_BRANCH | shasum -a 256 | cut -c 1-8 )
+BRANCHNAME_TRUNCATED=$(echo ${LOWERCASE_BRANCH//[^[:alnum:]]/-} | cut -c 1-20 | sed 's/^\(.*\)-$/\1/' )
+RELEASE_NAME="w$REPONAME_HASH-$BRANCHNAME_HASH-$BRANCHNAME_TRUNCATED"
+echo "export RELEASE_NAME='$RELEASE_NAME'" >> $BASH_ENV
+echo "Release name set to: $RELEASE_NAME"


### PR DESCRIPTION
This feature adds 2 deployment process scripts and adds commands in dockerfile to copy these scripts into image and set executable

/home/circleci/utils/set_release_name.sh  - contains release naming logic

/home/circleci/utils/gcloud_init.sh - contains google cloud cluster access setup logic

Testing is possible by using wunderio/silta-circleci-test from dockerhub (CI image already having  these scripts)