### PR TITLE
pinning gsutil to 4.38, as 4.39 rync has file copy issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN sudo apt-get install vim
 # Add gcloud CLI
 RUN curl -sSL https://sdk.cloud.google.com | bash \
   && rm -r /home/circleci/google-cloud-sdk/.install/.backup/ \
-  && sed -i -e 's/line.split(/line.rsplit(None, 9/g' /home/circleci/google-cloud-sdk/platform/gsutil/gslib/commands/rsync.py # patch broken rsync command
+  && /home/circleci/google-cloud-sdk/bin/gcloud components update --version 251.0.0 --quiet # rsync fails with gsutil 4.39 
 ENV PATH $PATH:/home/circleci/google-cloud-sdk/bin/
 
 # Add kubectl


### PR DESCRIPTION
gcloud sdk 251 seems to work with rsync properly.