### PR TITLE
Automatically skip reference data if the volume is not available.

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -412,6 +412,12 @@ commands:
               sleep 30
             fi
 
+            # Disable reference data if the required volume is not present.
+            if ! kubectl get pv | grep $CIRCLE_PROJECT_REPONAME | grep -q '-reference-data' ; then
+              echo "No reference data volume is found."
+              REFERENCE_DATA_OVERRIDE="--set referenceData.enabled=false"
+            fi
+
             helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
               --repo "<<parameters.chart_repository>>" \
               --set environmentName=$CIRCLE_BRANCH \
@@ -423,6 +429,7 @@ commands:
               --set shell.gitAuth.repositoryUrl="${CIRCLE_REPOSITORY_URL}" \
               --set shell.gitAuth.apiToken="${GITAUTH_API_TOKEN}" \
               --set clusterDomain=$CLUSTER_DOMAIN \
+              $REFERENCE_DATA_OVERRIDE \
               --namespace=${CIRCLE_PROJECT_REPONAME,,} \
               --values <<parameters.silta_config>>
 


### PR DESCRIPTION
When migrating projects to silta, the initial work typically happens in a feature branch, which means that the reference data volume (by default associated with the master environment) is not available yet. 

This change simply checks if a reference data volume is available, and if it is not then `referenceData.enabled=false` is passed to prevent a failure.