### PR TITLE
SLT-277: create reproducible composer builds

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -231,14 +231,14 @@ commands:
           steps:
             - run:
                 name: composer install
-                command: composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
+                command: composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader --classmap-authoritative
 
       - unless:
           condition: <<parameters.install-dev-dependencies>>
           steps:
             - run:
                 name: composer install
-                command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
+                command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader --classmap-authoritative
 
       - save_cache:
           paths:


### PR DESCRIPTION
The composer build process generates random prefixes in the autoloader, which means each build is different and the Docker image cache is not helpful. See https://github.com/composer/composer/issues/7049 for details.

Here's an example of this build that is successfully reusing an existing docker image for the php and shell images: https://circleci.com/gh/wunderio/drupal-project-k8s/6247