### PR TITLE
SLT-277: avoid recreating php docker images on every build

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -287,6 +287,8 @@ commands:
             IMAGE_TAG=`tar \
               --sort=name \
               --exclude-from=<<parameters.path>>/.dockerignore \
+              --exclude=vendor/composer \
+              --exclude=vendor/autoload.php \
               --mtime='2000-01-01 00:00Z' \
               --clamp-mtime \
               -cf - <<parameters.path>> <<parameters.dockerfile>> | sha1sum | cut -c 1-40`


### PR DESCRIPTION
The approach taken in https://github.com/wunderio/silta-circleci/pull/28 caused reproducible, but broken builds, and had to be reverted.

This takes a different approach, avoiding the changes to the autoloader from being taken into account when generating the hash for the docker image.

See https://circleci.com/gh/wunderio/drupal-project-k8s/6295 for a test build that re-uses the images from the previous build.