### PR TITLE
Remove large unused folders after composer install

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -243,6 +243,10 @@ commands:
                 name: composer install
                 command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
 
+      - run:
+          name: Clean up vendor tests
+          command: find {vendor,web/core,web/*/contrib}  \( -name .git -o -name test -o -name tests -o -name Tests \) | xargs rm -rf
+
       - save_cache:
           paths:
             - ./vendor


### PR DESCRIPTION
We already ignore third-party tests from our docker images (these represent a considerable portion of the codebase), but these are still repeatedly moved around the network when restoring CircleCI caches. This small optimisation saves us a few seconds on each build. 