### PR TITLE
Refactor bash scripts.

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -196,7 +196,6 @@ jobs:
               sleep 30
             fi
 
-            set +x # need to hide db password
             helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
               --repo '<<parameters.chart_repository>>' \
               --set environmentName="$CIRCLE_BRANCH" \
@@ -579,7 +578,6 @@ commands:
 
             # echo $WHITELISTED_IPS
 
-            set +x # need to hide db password
             helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
               --repo '<<parameters.chart_repository>>' \
               --set environmentName="$CIRCLE_BRANCH" \

--- a/orb.yml
+++ b/orb.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Build docker images
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             # Login to the docker registry.
             printenv GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
@@ -188,7 +188,7 @@ jobs:
       - run:
           name: Deploy helm release
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             if [[ $( helm list --failed | grep "$RELEASE_NAME" | cut -f2 ) -eq 1 ]]; then
               echo "Removing failed first release"
@@ -214,12 +214,12 @@ jobs:
           name: Deployment log
           when: always
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
             kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
       - run:
           name: Release information
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
             helm status "$RELEASE_NAME"
 
 # CircleCI commands
@@ -229,7 +229,7 @@ commands:
       - run:
           name: phpcs validation
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             if [ -f vendor/bin/phpcs ]; then
               vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
@@ -255,7 +255,7 @@ commands:
             - run:
                 name: composer install
                 command: |
-                  set -xeuo pipefail
+                  set -euo pipefail
 
                   composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
 
@@ -265,14 +265,14 @@ commands:
             - run:
                 name: composer install
                 command: |
-                  set -xeuo pipefail
+                  set -euo pipefail
 
                   composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
 
       - run:
           name: Clean up vendor tests
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             for directory in vendor web/core web/*/contrib
             do
@@ -323,7 +323,7 @@ commands:
       - run:
           name: Build <<parameters.identifier>> docker image
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             image_url="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}"-'<<parameters.identifier>>'
 
@@ -375,7 +375,7 @@ commands:
       - run:
           name: Install frontend dependencies
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             cd '<<parameters.path>>'
             npm install
@@ -383,7 +383,7 @@ commands:
       - run:
           name: Build frontend
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             cd '<<parameters.path>>'
             <<parameters.build-command>>
@@ -413,7 +413,7 @@ commands:
       - run:
           name: Install frontend dependencies
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             cd '<<parameters.path>>'
             yarn install
@@ -421,7 +421,7 @@ commands:
       - run:
           name: Build frontend
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             cd '<<parameters.path>>'
             <<parameters.build-command>>
@@ -436,7 +436,7 @@ commands:
       - run:
           name: Login to the docker registry
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             printenv GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin "https://$DOCKER_REPO_HOST"
 
@@ -466,7 +466,7 @@ commands:
       - run:
           name: Set release name
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             # Release name length is 37 chars long, which leaves max 16 chars for kubernetes resource name.
             # Release name is prefixed with w because  it _HAS_ to start with alphabetic character. w 4 wunder.
@@ -490,7 +490,7 @@ commands:
       - run:
           name: Google Cloud login
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             # Save key, authenticate and set compute zone.
             printenv GCLOUD_KEY_JSON > "$HOME/gcloud-service-key.json"
@@ -505,7 +505,7 @@ commands:
       - run:
           name: Clean up failed Helm releases
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             if [[ $( helm list --failed | grep "$RELEASE_NAME"  | cut -f2 ) -eq 1 ]]; then
               # Remove any existing post-release hook, since it's technically not part of the release.
@@ -532,7 +532,7 @@ commands:
       - run:
           name: Deploy helm release
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             # Secret management
             secrets='<<parameters.decrypt_files>>'
@@ -599,14 +599,14 @@ commands:
           name: Deployment log
           when: always
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
 
       - run:
           name: Release information
           command: |
-            set -xeuo pipefail
+            set -euo pipefail
 
             # Display only the part following NOTES from the helm status.
             helm status "$RELEASE_NAME" | sed -e '1,/NOTES/d'

--- a/orb.yml
+++ b/orb.yml
@@ -36,6 +36,9 @@ jobs:
       - run:
           name: Silta basic checks
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -euo pipefail
+
             files=(
               silta/silta.yml
               silta/silta-prod.yml
@@ -46,8 +49,8 @@ jobs:
               web/.dockerignore
             )
 
-            for file in ${files[@]}; do
-              if [ -f $file ]; then
+            for file in "${files[@]}"; do
+              if [ -f "$file" ]; then
                 echo "✅ $file is present"
               else
                 echo "❌ $file is missing from the repository."
@@ -135,20 +138,26 @@ jobs:
       - run:
           name: Build docker images
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
             # Login to the docker registry.
-            echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
+            printenv GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://eu.gcr.io
 
             # Build the Nginx image and push it to the repository.
-            docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 -f silta/nginx.Dockerfile web
-            docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1
+            image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1"
+            docker build -t "$image" -f silta/nginx.Dockerfile web
+            docker push "$image"
 
             # Build the Drupal image and push it to the repository.
-            docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 -f silta/php.Dockerfile .
-            docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1
+            image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1"
+            docker build -t "$image" -f silta/php.Dockerfile .
+            docker push "$image"
 
             # Build the Shell image and push it to the repository.
-            docker build -t $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 -f silta/shell.Dockerfile .
-            docker push $DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1
+            image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1"
+            docker build -t "$image" -f silta/shell.Dockerfile .
+            docker push "$image"
 
   # Deprecated in favor of drupal-build-deploy.
   drupal-deploy:
@@ -181,33 +190,42 @@ jobs:
       - run:
           name: Deploy helm release
           command: |
-            if [[ "$( helm list --failed | grep $RELEASE_NAME  | cut -f2 )" -eq 1 ]]; then
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            if [[ $( helm list --failed | grep "$RELEASE_NAME" | cut -f2 ) -eq 1 ]]; then
               echo "Removing failed first release"
-              helm delete --purge $RELEASE_NAME
+              helm delete --purge "$RELEASE_NAME"
               sleep 30
             fi
 
-            helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
-              --repo "<<parameters.chart_repository>>" \
-              --set environmentName=$CIRCLE_BRANCH \
-              --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1 \
-              --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1 \
-              --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1 \
-              --set mariadb.rootUser.password=$DB_ROOT_PASS \
-              --set mariadb.db.password=$DB_USER_PASS \
-              --set shell.gitAuth.repositoryUrl="${CIRCLE_REPOSITORY_URL}" \
-              --set shell.gitAuth.apiToken="${GITAUTH_API_TOKEN}" \
-              --set clusterDomain=$CLUSTER_DOMAIN \
-              --namespace=${CIRCLE_PROJECT_REPONAME,,} \
-              --values <<parameters.silta_config>>
+            set +x # need to hide db password
+            helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
+              --repo '<<parameters.chart_repository>>' \
+              --set environmentName="$CIRCLE_BRANCH" \
+              --set php.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$CIRCLE_SHA1" \
+              --set nginx.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$CIRCLE_SHA1" \
+              --set shell.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$CIRCLE_SHA1" \
+              --set mariadb.rootUser.password="$DB_ROOT_PASS" \
+              --set mariadb.db.password="$DB_USER_PASS" \
+              --set shell.gitAuth.repositoryUrl="$CIRCLE_REPOSITORY_URL" \
+              --set shell.gitAuth.apiToken="$GITAUTH_API_TOKEN" \
+              --set clusterDomain="$CLUSTER_DOMAIN" \
+              --namespace="${CIRCLE_PROJECT_REPONAME,,}" \
+              --values '<<parameters.silta_config>>'
       - run:
           name: Deployment log
           when: always
           command: |
-            kubectl logs job/${RELEASE_NAME}-post-release -n ${CIRCLE_PROJECT_REPONAME,,} -f --timestamps=true
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+            kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
       - run:
           name: Release information
-          command: helm status $RELEASE_NAME
+          command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+            helm status "$RELEASE_NAME"
 
 # CircleCI commands
 commands:
@@ -216,8 +234,10 @@ commands:
       - run:
           name: phpcs validation
           command: |
-            if [ -f vendor/bin/phpcs ]
-            then
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            if [ -f vendor/bin/phpcs ]; then
               vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
               vendor/bin/phpcs --standard=phpcs.xml -s --colors
             else
@@ -240,23 +260,34 @@ commands:
           steps:
             - run:
                 name: composer install
-                command: composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
+                command: |
+                  export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+                  set -xeuo pipefail
+
+                  composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
 
       - unless:
           condition: <<parameters.install-dev-dependencies>>
           steps:
             - run:
                 name: composer install
-                command: composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
+                command: |
+                  export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+                  set -xeuo pipefail
+
+                  composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
 
       - run:
           name: Clean up vendor tests
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
             for directory in vendor web/core web/*/contrib
             do
-              if [ -d $directory ]
+              if [ -d "$directory" ]
               then
-                find $directory \( -name .git -o -name test -o -name tests -o -name Tests \) | xargs rm -rf
+                find "$directory" \( -name .git -o -name test -o -name tests -o -name Tests \) -print0 | xargs -0 rm -rf
               fi
             done
 
@@ -301,35 +332,38 @@ commands:
       - run:
           name: Build <<parameters.identifier>> docker image
           command: |
-            IMAGE_URL=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-<<parameters.identifier>>
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            image_url="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}"-'<<parameters.identifier>>'
 
             # Only exclude files
-            if [ -f <<parameters.path>>/.dockerignore ]
+            exclude_dockerignore=''
+            if [ -f '<<parameters.path>>/.dockerignore' ]
             then
-              EXCLUDE_DOCKERIGNORE="--exclude-from=<<parameters.path>>/.dockerignore"
+              exclude_dockerignore=--exclude-from='<<parameters.path>>'/.dockerignore
             fi
 
             # Take a hash of all files in the folder except those ignored by docker.
             # Also make sure modification time or order play no role.
-            IMAGE_TAG=`tar \
+            image_tag=$(tar \
               --sort=name \
-              $EXCLUDE_DOCKERIGNORE \
+              "$exclude_dockerignore" \
               --exclude=vendor/composer \
               --exclude=vendor/autoload.php \
               --mtime='2000-01-01 00:00Z' \
               --clamp-mtime \
-              -cf - <<parameters.path>> <<parameters.dockerfile>> | sha1sum | cut -c 1-40`
+              -cf - '<<parameters.path>>' '<<parameters.dockerfile>>' | sha1sum | cut -c 1-40)
 
-            if gcloud container images list-tags $IMAGE_URL | grep -q $IMAGE_TAG;
-            then
+            if gcloud container images list-tags "$image_url" | grep -q "$image_tag"; then
               echo "This <<parameters.identifier>> image has already been built, the existing image from the Docker repository will be used."
             else
-              docker build -t $IMAGE_URL:$IMAGE_TAG -f <<parameters.dockerfile>> <<parameters.path>>
-              docker push $IMAGE_URL:$IMAGE_TAG
+              docker build -t "$image_url:$image_tag" -f '<<parameters.dockerfile>>' '<<parameters.path>>'
+              docker push "$image_url:$image_tag"
             fi
 
             # Persist the image tag so it is available during deployment.
-            echo "export <<parameters.identifier>>_HASH='$IMAGE_TAG'" >> $BASH_ENV
+            echo "export <<parameters.identifier>>_HASH='$image_tag'" >> "$BASH_ENV"
 
   npm-install-build:
     parameters:
@@ -351,13 +385,19 @@ commands:
       - run:
           name: Install frontend dependencies
           command: |
-            cd <<parameters.path>>
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            cd '<<parameters.path>>'
             npm install
 
       - run:
           name: Build frontend
           command: |
-            cd <<parameters.path>>
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            cd '<<parameters.path>>'
             <<parameters.build-command>>
 
       - save_cache:
@@ -385,13 +425,19 @@ commands:
       - run:
           name: Install frontend dependencies
           command: |
-            cd <<parameters.path>>
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            cd '<<parameters.path>>'
             yarn install
 
       - run:
           name: Build frontend
           command: |
-            cd <<parameters.path>>
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            cd '<<parameters.path>>'
             <<parameters.build-command>>
 
       - save_cache:
@@ -403,7 +449,11 @@ commands:
     steps:
       - run:
           name: Login to the docker registry
-          command: echo $GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin https://$DOCKER_REPO_HOST
+          command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            printenv GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin "https://$DOCKER_REPO_HOST"
 
   drupal-docker-build:
     steps:
@@ -431,46 +481,56 @@ commands:
       - run:
           name: Set release name
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
             # Release name length is 37 chars long, which leaves max 16 chars for kubernetes resource name.
             # Release name is prefixed with w because  it _HAS_ to start with alphabetic character. w 4 wunder.
-            BRANCHNAME_LOWER=${CIRCLE_BRANCH,,}
-            BRANCHNAME=${BRANCHNAME_LOWER//[^[:alnum:]]/-}
-            BRANCHNAME_HASH=$(echo -n $BRANCHNAME | shasum -a 256 | cut -c 1-4 )
-            BRANCHNAME_TRUNCATED=$(echo $BRANCHNAME | cut -c 1-15 | sed 's/^\(.*\)-$/\1/' )
-            REPONAME=${CIRCLE_PROJECT_REPONAME,,}
-            REPONAME_HASH=$(echo -n $REPONAME | shasum -a 256 | cut -c 1-4 )
-            REPONAME_TRUNCATED=$(echo $REPONAME | cut -c 1-15 | sed 's/^\(.*\)-$/\1/' )
+            branchname_lower="${CIRCLE_BRANCH,,}"
+            branchname="${branchname_lower//[^[:alnum:]]/-}"
+            branchname_hash=$(printf "$branchname" | shasum -a 256 | cut -c 1-4 )
+            branchname_truncated=$(printf "$branchname" | cut -c 1-15 | sed 's/^\(.*\)-$/\1/' )
+            reponame="${CIRCLE_PROJECT_REPONAME,,}"
+            reponame_hash=$(printf "$reponame" | shasum -a 256 | cut -c 1-4 )
+            reponame_truncated=$(printf "$reponame" | cut -c 1-15 | sed 's/^\(.*\)-$/\1/' )
             # Truncate long names
-            if [ ${#BRANCHNAME} -ge 20 ]; then BRANCHNAME=$BRANCHNAME_TRUNCATED-$BRANCHNAME_HASH; fi;
-            if [ ${#REPONAME} -ge 20 ]; then REPONAME=$REPONAME_TRUNCATED-$REPONAME_HASH; fi;
-            echo "export RELEASE_NAME='$REPONAME--$BRANCHNAME'" >> $BASH_ENV
+            if [ ${#branchname} -ge 20 ]; then branchname="$branchname_truncated-$branchname_hash"; fi
+            if [ ${#reponame} -ge 20 ]; then reponame="$reponame_truncated-$reponame_hash"; fi
+            name="$reponame--$branchname"
+            echo "export RELEASE_NAME='$name'" >> "$BASH_ENV"
 
-            echo "The release name for this branch is $REPONAME--$BRANCHNAME"
+            echo "The release name for this branch is $name"
 
   gcloud-login:
     steps:
       - run:
           name: Google Cloud login
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
             # Save key, authenticate and set compute zone.
-            echo $GCLOUD_KEY_JSON > ${HOME}/gcloud-service-key.json
-            gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json --project $GCLOUD_PROJECT_NAME
-            gcloud config set compute/zone $GCLOUD_COMPUTE_ZONE
+            printenv GCLOUD_KEY_JSON > "$HOME/gcloud-service-key.json"
+            gcloud auth activate-service-account --key-file="$HOME/gcloud-service-key.json" --project "$GCLOUD_PROJECT_NAME"
+            gcloud config set compute/zone "$GCLOUD_COMPUTE_ZONE"
 
             # Updates a kubeconfig file with appropriate credentials and endpoint information.
-            gcloud container clusters get-credentials $GCLOUD_CLUSTER_NAME --zone $GCLOUD_COMPUTE_ZONE --project $GCLOUD_PROJECT_NAME
+            gcloud container clusters get-credentials "$GCLOUD_CLUSTER_NAME" --zone "$GCLOUD_COMPUTE_ZONE" --project "$GCLOUD_PROJECT_NAME"
 
   helm-cleanup:
     steps:
       - run:
           name: Clean up failed Helm releases
           command: |
-            if [[ "$( helm list --failed | grep $RELEASE_NAME  | cut -f2 )" -eq 1 ]]; then
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            if [[ $( helm list --failed | grep "$RELEASE_NAME"  | cut -f2 ) -eq 1 ]]; then
               # Remove any existing post-release hook, since it's technically not part of the release.
-              kubectl delete job -n ${CIRCLE_PROJECT_REPONAME,,} $RELEASE_NAME-post-release 2> /dev/null || true
+              kubectl delete job -n "${CIRCLE_PROJECT_REPONAME,,}" "$RELEASE_NAME-post-release" 2> /dev/null || true
 
               echo "Removing failed first release"
-              helm delete --purge $RELEASE_NAME
+              helm delete --purge "$RELEASE_NAME"
 
               sleep 30
             fi
@@ -490,32 +550,39 @@ commands:
       - run:
           name: Deploy helm release
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
 
             # Secret management
-            if [[ ! -z "<<parameters.decrypt_files>>" ]]; then
+            secrets='<<parameters.decrypt_files>>'
+            if [[ ! -z "$secrets" ]]; then
               echo "Decrypting secrets"
-              secrets="<<parameters.decrypt_files>>" 
-              for i in ${secrets//,/}; do 
-                echo $i;
-                openssl enc -d -aes-256-cbc -pbkdf2 -in $i -out $i.tmp -pass pass:${SECRET_KEY};
-                mv $i.tmp $i;
+              for file in ${secrets//,/}
+              do
+                echo "$file"
+                tmp=$(mktemp)
+                openssl enc -d -aes-256-cbc -pbkdf2 -in "$file" -out "$tmp" -pass env:SECRET_KEY
+                mv -v "$tmp" "$file"
               done
             fi
 
-            if [[ "$( helm list --failed | grep $RELEASE_NAME  | cut -f2 )" -eq 1 ]]; then
+            reponame="${CIRCLE_PROJECT_REPONAME,,}"
+
+            if [[ $( helm list --failed | grep "$RELEASE_NAME" | cut -f2 ) -eq 1 ]]; then
               # Remove any existing post-release hook, since it's technically not part of the release.
-              kubectl delete job -n ${CIRCLE_PROJECT_REPONAME,,} $RELEASE_NAME-post-release 2> /dev/null || true
+              kubectl delete job -n "$reponame" "$RELEASE_NAME-post-release" 2> /dev/null || true
 
               echo "Removing failed first release"
-              helm delete --purge $RELEASE_NAME
+              helm delete --purge "$RELEASE_NAME"
 
               sleep 30
             fi
 
             # Disable reference data if the required volume is not present.
-            REFERENCE_VOLUME=`kubectl get pv | grep "${CIRCLE_PROJECT_REPONAME,,}\/.*-reference-data"` || true
-            if [[ -z $REFERENCE_VOLUME ]] ; then
-              REFERENCE_DATA_OVERRIDE="--set referenceData.skipMount=true"
+            reference_volume=$(kubectl get pv | grep --extended-regexp "$reponame/.*-reference-data") || true
+            reference_data_override=''
+            if [[ -z "$reference_volume" ]] ; then
+              reference_data_override='--set referenceData.skipMount=true'
             fi
 
             # Structure IP whitelist
@@ -531,29 +598,36 @@ commands:
 
             # echo $WHITELISTED_IPS
 
-            helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
-              --repo "<<parameters.chart_repository>>" \
-              --set environmentName=$CIRCLE_BRANCH \
-              --set php.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-php:$php_HASH \
-              --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$nginx_HASH \
-              --set shell.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-shell:$shell_HASH \
-              --set mariadb.rootUser.password=$DB_ROOT_PASS \
-              --set mariadb.db.password=$DB_USER_PASS \
-              --set shell.gitAuth.repositoryUrl="${CIRCLE_REPOSITORY_URL}" \
-              --set shell.gitAuth.apiToken="${GITAUTH_API_TOKEN}" \
-              --set clusterDomain=$CLUSTER_DOMAIN \
-              $REFERENCE_DATA_OVERRIDE \
-              --namespace=${CIRCLE_PROJECT_REPONAME,,} \
-              --values <<parameters.silta_config>>
+            set +x # need to hide db password
+            helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
+              --repo '<<parameters.chart_repository>>' \
+              --set environmentName="$CIRCLE_BRANCH" \
+              --set php.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-php:$php_HASH" \
+              --set nginx.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-nginx:$nginx_HASH" \
+              --set shell.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-shell:$shell_HASH" \
+              --set mariadb.rootUser.password="$DB_ROOT_PASS" \
+              --set mariadb.db.password="$DB_USER_PASS" \
+              --set shell.gitAuth.repositoryUrl="$CIRCLE_REPOSITORY_URL" \
+              --set shell.gitAuth.apiToken="$GITAUTH_API_TOKEN" \
+              --set clusterDomain="$CLUSTER_DOMAIN" \
+              "$reference_data_override" \
+              --namespace="$reponame" \
+              --values '<<parameters.silta_config>>'
 
       - run:
           name: Deployment log
           when: always
           command: |
-            kubectl logs job/${RELEASE_NAME}-post-release -n ${CIRCLE_PROJECT_REPONAME,,} -f --timestamps=true
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
+            kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
 
       - run:
           name: Release information
           command: |
+            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+            set -xeuo pipefail
+
             # Display only the part following NOTES from the helm status.
-            helm status $RELEASE_NAME | sed -e '1,/NOTES/d'
+            helm status "$RELEASE_NAME" | sed -e '1,/NOTES/d'

--- a/orb.yml
+++ b/orb.yml
@@ -163,8 +163,8 @@ jobs:
                 command: |
                   set -euo pipefail
                   reponame="${CIRCLE_PROJECT_REPONAME,,}"
-                  helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
-                    --repo "<<parameters.chart_repository>>" \
+                  helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
+                    --repo '<<parameters.chart_repository>>' \
                     --set environmentName="$CIRCLE_BRANCH" \
                     --set frontend.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-node:$node_HASH" \
                     --set clusterDomain=$CLUSTER_DOMAIN \
@@ -536,10 +536,10 @@ commands:
 
             # Override Database credentials if specified
             if [[ ! -z "$DB_ROOT_PASS" ]] ; then
-              DB_ROOT_PASS_OVERRIDE="--set mariadb.rootUser.password=$DB_ROOT_PASS"
+              db_root_pass_override="--set mariadb.rootUser.password=$DB_ROOT_PASS"
             fi
             if [[ ! -z "$DB_USER_PASS" ]] ; then
-              DB_USER_PASS_OVERRIDE="--set mariadb.db.password=$DB_USER_PASS"
+              db_user_pass_override="--set mariadb.db.password=$DB_USER_PASS"
             fi
 
             helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
@@ -548,12 +548,12 @@ commands:
               --set php.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-php:$php_HASH" \
               --set nginx.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-nginx:$nginx_HASH" \
               --set shell.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-shell:$shell_HASH" \
-              $DB_ROOT_PASS_OVERRIDE \
-              $DB_USER_PASS_OVERRIDE \
+              $db_root_pass_override \
+              $db_user_pass_override \
               --set shell.gitAuth.repositoryUrl="$CIRCLE_REPOSITORY_URL" \
               --set shell.gitAuth.apiToken="$GITAUTH_API_TOKEN" \
               --set clusterDomain="$CLUSTER_DOMAIN" \
-              "$reference_data_override" \
+              $reference_data_override \
               --namespace="$reponame" \
               --values '<<parameters.silta_config>>'
 

--- a/orb.yml
+++ b/orb.yml
@@ -161,13 +161,15 @@ jobs:
             - run:
                 name: Deploy helm release
                 command: |
+                  set -euo pipefail
+                  reponame="${CIRCLE_PROJECT_REPONAME,,}"
                   helm upgrade --install $RELEASE_NAME <<parameters.chart_name>> \
                     --repo "<<parameters.chart_repository>>" \
-                    --set environmentName=$CIRCLE_BRANCH \
-                    --set frontend.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-node:$node_HASH \
+                    --set environmentName="$CIRCLE_BRANCH" \
+                    --set frontend.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-node:$node_HASH" \
                     --set clusterDomain=$CLUSTER_DOMAIN \
-                    --namespace=${CIRCLE_PROJECT_REPONAME,,} \
-                    --values <<parameters.silta_config>>
+                    --namespace="$reponame" \
+                    --values '<<parameters.silta_config>>'
 
             - helm-release-information
 
@@ -455,10 +457,11 @@ commands:
           name: Clean up failed Helm releases
           command: |
             set -euo pipefail
+            reponame="${CIRCLE_PROJECT_REPONAME,,}"
 
             if [[ $( helm list --failed | grep "$RELEASE_NAME"  | cut -f2 ) -eq 1 ]]; then
               # Remove any existing post-release hook, since it's technically not part of the release.
-              kubectl delete job -n "${CIRCLE_PROJECT_REPONAME,,}" "$RELEASE_NAME-post-release" 2> /dev/null || true
+              kubectl delete job -n "$reponame" "$RELEASE_NAME-post-release" 2> /dev/null || true
 
               echo "Removing failed first release"
               helm delete --purge "$RELEASE_NAME"
@@ -559,16 +562,16 @@ commands:
           when: always
           command: |
             set -euo pipefail
-
-            kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
+            reponame="${CIRCLE_PROJECT_REPONAME,,}"
+            kubectl logs "job/$RELEASE_NAME-post-release" -n "$reponame" -f --timestamps=true
 
       - run:
           name: Wait for resources to be ready
           command: |
             set -euo pipefail
-
+            reponame="${CIRCLE_PROJECT_REPONAME,,}"
             # Get all deployments in the release and check the status of each one.
-            kubectl get deployment -n ${CIRCLE_PROJECT_REPONAME,,} -l release=${RELEASE_NAME} -o name | xargs -n 1 kubectl rollout status -n ${CIRCLE_PROJECT_REPONAME,,}
+            kubectl get deployment -n "$reponame" -l "release=${RELEASE_NAME}" -o name | xargs -n 1 kubectl rollout status -n "$reponame"
             
             # Display only the part following NOTES from the helm status.
             helm status "$RELEASE_NAME" | sed -e '1,/NOTES/d'

--- a/orb.yml
+++ b/orb.yml
@@ -36,7 +36,6 @@ jobs:
       - run:
           name: Silta basic checks
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -euo pipefail
 
             files=(
@@ -138,7 +137,6 @@ jobs:
       - run:
           name: Build docker images
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             # Login to the docker registry.
@@ -190,7 +188,6 @@ jobs:
       - run:
           name: Deploy helm release
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             if [[ $( helm list --failed | grep "$RELEASE_NAME" | cut -f2 ) -eq 1 ]]; then
@@ -217,13 +214,11 @@ jobs:
           name: Deployment log
           when: always
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
             kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
       - run:
           name: Release information
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
             helm status "$RELEASE_NAME"
 
@@ -234,7 +229,6 @@ commands:
       - run:
           name: phpcs validation
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             if [ -f vendor/bin/phpcs ]; then
@@ -261,7 +255,6 @@ commands:
             - run:
                 name: composer install
                 command: |
-                  export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
                   set -xeuo pipefail
 
                   composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
@@ -272,7 +265,6 @@ commands:
             - run:
                 name: composer install
                 command: |
-                  export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
                   set -xeuo pipefail
 
                   composer install -n --prefer-dist --ignore-platform-reqs --no-dev --optimize-autoloader
@@ -280,7 +272,6 @@ commands:
       - run:
           name: Clean up vendor tests
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             for directory in vendor web/core web/*/contrib
@@ -332,7 +323,6 @@ commands:
       - run:
           name: Build <<parameters.identifier>> docker image
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             image_url="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}"-'<<parameters.identifier>>'
@@ -385,7 +375,6 @@ commands:
       - run:
           name: Install frontend dependencies
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             cd '<<parameters.path>>'
@@ -394,7 +383,6 @@ commands:
       - run:
           name: Build frontend
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             cd '<<parameters.path>>'
@@ -425,7 +413,6 @@ commands:
       - run:
           name: Install frontend dependencies
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             cd '<<parameters.path>>'
@@ -434,7 +421,6 @@ commands:
       - run:
           name: Build frontend
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             cd '<<parameters.path>>'
@@ -450,7 +436,6 @@ commands:
       - run:
           name: Login to the docker registry
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             printenv GCLOUD_KEY_JSON | docker login -u _json_key --password-stdin "https://$DOCKER_REPO_HOST"
@@ -481,7 +466,6 @@ commands:
       - run:
           name: Set release name
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             # Release name length is 37 chars long, which leaves max 16 chars for kubernetes resource name.
@@ -506,7 +490,6 @@ commands:
       - run:
           name: Google Cloud login
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             # Save key, authenticate and set compute zone.
@@ -522,7 +505,6 @@ commands:
       - run:
           name: Clean up failed Helm releases
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             if [[ $( helm list --failed | grep "$RELEASE_NAME"  | cut -f2 ) -eq 1 ]]; then
@@ -550,7 +532,6 @@ commands:
       - run:
           name: Deploy helm release
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             # Secret management
@@ -618,7 +599,6 @@ commands:
           name: Deployment log
           when: always
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             kubectl logs "job/$RELEASE_NAME-post-release" -n "${CIRCLE_PROJECT_REPONAME,,}" -f --timestamps=true
@@ -626,7 +606,6 @@ commands:
       - run:
           name: Release information
           command: |
-            export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
             set -xeuo pipefail
 
             # Display only the part following NOTES from the helm status.


### PR DESCRIPTION
Changes:

- Replacing echo $GCLOUD_KEY_JSON by printenv GCLOUD_KEY_JSON
- Removing irrelevant ; at end of lines
- In some places put `if` and `then` on the same line for consistency and readability 
- Null-terminating arbitrary file paths
- Leaving only ENVIRONMENT and SPECIAL variables uppercase, rest lowercase as "industry standard" not to mix then up
- Using `mktemp` for temporary files
- Fixing couple of “unbound variable” errors
- Fix variable quoting.
- Use 'set -euo pipefail' by default.
- Deduplicate repeating code.

-------------------------------------------

Before merging, it has to be tested.

As I'm not able to test it, I did changes "in the dark", so probably some bugs emerge too. Or unexpected behaviour.

Each modified code has to be tested:

- Check the functional outcome

There were few things I was a bit unsure of:

- I don't think removing tests in "Clean up vendor tests" is a good idea. We have tried to implement that in client project, and run into troubles, because some modules did depend on tests being present.
- Is it true, that ` <<parameters.build-command>>` may also contain arguments? (in various places)