### PR TITLE
Add the codecentric and wunderio helm repositories.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN curl -o /tmp/$FILENAME ${HELM_URL} \
   && sudo mv /tmp/linux-amd64/helm /bin/helm \
   && helm init --client-only \
   && helm plugin install https://github.com/lrills/helm-unittest \
+  && helm repo add codecentric https://codecentric.github.io/helm-charts \
+  && helm repo add wunderio https://storage.googleapis.com/charts.wdr.io \
   && helm repo remove local
 
 # Add custom php config and lift memory limit.


### PR DESCRIPTION
Having these in the base images means we don't need to add those as part of the CI process.