### PR TITLE
SLT-333

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -432,7 +432,11 @@ commands:
               echo "Removing failed first release"
               helm delete --purge $RELEASE_NAME
 
-              sleep 30
+              until [[ -z `kubectl get pv | grep "$RELEASE_NAME-public-files"` ]]
+              do
+                echo "Waiting for volumes to be deleted."
+                sleep 5
+              done
             fi
 
   helm-release-information:


### PR DESCRIPTION
We have a mechanism to clean up failed first releases, but the public files volume is often still in a terminating state. Rather than waiting a fixed amount of time, we can check every 5 seconds if the volume is present. In some cases we could reduce the waiting time, and when things take longer we would avoid a failure due to a conflict with existing volumes.