### PR TITLE
Separate npm install and npm build

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -322,14 +322,11 @@ commands:
             # Persist the image tag so it is available during deployment.
             echo "export <<parameters.identifier>>_HASH='$image_tag'" >> "$BASH_ENV"
 
-  npm-install-build:
+  npm-install:
     parameters:
       path:
         type: string
         default: "."
-      build-command:
-        type: string
-        default: "npm run build"
       cache-version:
         type: string
         default: "v1"
@@ -347,6 +344,27 @@ commands:
             cd '<<parameters.path>>'
             npm install
 
+      - save_cache:
+          paths:
+            - <<parameters.path>>/node_modules
+          key: <<parameters.cache-version>>-npm-{{ checksum "<<parameters.path>>/package-lock.json" }}
+
+  npm-install-build:
+    parameters:
+      path:
+        type: string
+        default: "."
+      build-command:
+        type: string
+        default: "npm run build"
+      cache-version:
+        type: string
+        default: "v1"
+    steps:
+      - npm-install:
+          path: <<parameters.path>>
+          cache-version: <<parameters.cache-version>>
+
       - run:
           name: Build frontend
           command: |
@@ -354,11 +372,6 @@ commands:
 
             cd '<<parameters.path>>'
             <<parameters.build-command>>
-
-      - save_cache:
-          paths:
-            - <<parameters.path>>/node_modules
-          key: <<parameters.cache-version>>-npm-{{ checksum "<<parameters.path>>/package-lock.json" }}
 
   yarn-install-build:
     parameters:


### PR DESCRIPTION
This change will separate npm install and npm build commands. This way we may use npm install job without forcing the build command.

**Note**
  This change will `save_cache` before `npm run build` assuming that build should not change `node_modules` directory (which is the cache contents).

  Previously `save_cache` was called last thing in the steps, even after `npm run build`