### PR TITLE
Allow overriding image build steps for frontend-build-deploy job

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -143,6 +143,13 @@ jobs:
       cluster_domain:
         type: env_var_name
         default: CLUSTER_DOMAIN
+      image_build_steps:
+        type: steps
+        default: 
+        - build-docker-image:
+            dockerfile: 'silta/node.Dockerfile'
+            path: '.'
+            identifier: 'node'
     steps:
       - checkout
 
@@ -154,10 +161,7 @@ jobs:
 
       - docker-login
 
-      - build-docker-image:
-          dockerfile: silta/node.Dockerfile
-          path: .
-          identifier: node
+      - steps: <<parameters.image_build_steps>>
 
       - unless:
           condition: <<parameters.skip-deployment>>
@@ -171,10 +175,18 @@ jobs:
                 command: |
                   set -euo pipefail
                   reponame="${CIRCLE_PROJECT_REPONAME,,}"
+                  image_overrides=""
+                  for var in `env | grep _IMAGE_IDENTIFIER`; do
+                    identifier=`echo $var | cut -f 2 -d "="`
+                    image_url="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-$identifier"
+                    image_tag="${identifier}_HASH"
+                    image_overrides="$image_overrides --set services.${identifier}.image=${image_url}:${!image_tag}"
+                  done
+
                   helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
                     --repo '<<parameters.chart_repository>>' \
                     --set environmentName="$CIRCLE_BRANCH" \
-                    --set frontend.image="$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/$reponame-node:$node_HASH" \
+                    $image_overrides \
                     --set clusterDomain=${<<parameters.cluster_domain>>} \
                     --namespace="$reponame" \
                     --values '<<parameters.silta_config>>'
@@ -319,8 +331,12 @@ commands:
               docker push "$image_url:$image_tag"
             fi
 
-            # Persist the image tag so it is available during deployment.
+            # Persist the image identifier and tag so it is available during deployment.
+            echo "export <<parameters.identifier>>_IMAGE_IDENTIFIER='<<parameters.identifier>>'" >> "$BASH_ENV"
             echo "export <<parameters.identifier>>_HASH='$image_tag'" >> "$BASH_ENV"
+            
+            
+
 
   npm-install-build:
     parameters:


### PR DESCRIPTION
This allows running multiple nodeJS containers in a single deployment.

Frontend chart targeted deployment here: https://github.com/wunderio/frontend-project-k8s