### PR TITLE
Transition to Helm 3

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -477,7 +477,7 @@ commands:
               kubectl delete job -n "$reponame" "$RELEASE_NAME-post-release" 2> /dev/null || true
 
               echo "Removing failed first release."
-              helm delete --purge "$RELEASE_NAME"
+              helm delete "$RELEASE_NAME"
 
               echo "Delete persistent volume claims left over from statefulsets."
               kubectl get pvc -n "$reponame" -l release="$RELEASE_NAME" -o name | xargs -n 1 kubectl delete --ignore-not-found=true -n "$reponame"

--- a/orb.yml
+++ b/orb.yml
@@ -496,7 +496,7 @@ commands:
           name: Release information
           command: |
             # Display only the part following NOTES from the helm status.
-            helm status "$RELEASE_NAME" | sed -e '1,/NOTES/d'
+            helm get notes "$RELEASE_NAME"
 
   decrypt-files:
     parameters:

--- a/orb.yml
+++ b/orb.yml
@@ -170,7 +170,7 @@ jobs:
           condition: <<parameters.skip-deployment>>
           steps:
             - set-release-name
-
+            - helm3-upgrade
             - helm-cleanup
 
             - run:

--- a/orb.yml
+++ b/orb.yml
@@ -583,7 +583,7 @@ commands:
               $reference_data_override \
               --namespace="$reponame" \
               --values '<<parameters.silta_config>>' \
-              --timeout 600s) 2>&1) || EXIT_CODE=$?
+              --timeout 10m) 2>&1) || EXIT_CODE=$?
 
             if [[ $output == *"BackoffLimitExceeded"* ]]; then
               # Don't show BackoffLimitExceeded, it confuses everyone.

--- a/orb.yml
+++ b/orb.yml
@@ -583,7 +583,7 @@ commands:
               $reference_data_override \
               --namespace="$reponame" \
               --values '<<parameters.silta_config>>' \
-              --timeout 600) 2>&1) || EXIT_CODE=$?
+              --timeout 600s) 2>&1) || EXIT_CODE=$?
 
             if [[ $output == *"BackoffLimitExceeded"* ]]; then
               # Don't show BackoffLimitExceeded, it confuses everyone.

--- a/orb.yml
+++ b/orb.yml
@@ -472,7 +472,7 @@ commands:
           command: |
             reponame="${CIRCLE_PROJECT_REPONAME,,}"
 
-            if [[ $( helm list --failed "$RELEASE_NAME" | tail -1 | cut -f2 ) -eq 1 ]]; then
+            if [[ $( helm list --failed --filter "$RELEASE_NAME" | tail -1 | cut -f3 ) -eq 1 ]]; then
               # Remove any existing post-release hook, since it's technically not part of the release.
               kubectl delete job -n "$reponame" "$RELEASE_NAME-post-release" 2> /dev/null || true
 

--- a/orb.yml
+++ b/orb.yml
@@ -114,6 +114,7 @@ jobs:
             - drupal-docker-build
             - set-release-name
             - steps: <<parameters.pre-release>>
+            - helm3-upgrade
             - drupal-helm-deploy:
                 chart_name: <<parameters.chart_name>>
                 chart_repository: <<parameters.chart_repository>>
@@ -609,3 +610,22 @@ commands:
             kubectl get deployment -n "$reponame" -l "release=${RELEASE_NAME}" -o name | xargs -n 1 kubectl rollout status -n "$reponame"
             
       - helm-release-information
+
+  helm3-upgrade:
+    steps:
+      - run:
+          name: Install helm 3
+          command: |
+            curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+            helm plugin install https://github.com/helm/helm-2to3
+            helm 2to3 move config
+
+      - run:
+          name: Migrate eventual helm 2 releases
+          command: |
+            helm 2to3 convert "$RELEASE_NAME" --delete-v2-releases || true
+
+      - run:
+          name: Set current kubernetes namespace
+          command: |
+            kubectl config set-context --current --namespace="${CIRCLE_PROJECT_REPONAME,,}"


### PR DESCRIPTION
This is one of the steps in the transition to helm 3. Here's what this does:

- Download helm 3 as part of the build process (we'll replace that with simply putting helm3 in the base image once we are done with the transition)
- Migrate the current release to helm 3 and get rid of the helm 2 release. Note that this does nothing to the kubernetes resources, it just migrates the metadata.
- Minor adjustments to the helm calls to work with helm 3.

This has been tested in the `test/helm-3` branch in the drupal-project-k8s and frontend-project-k8s repositories, including the case where a release fails, and where a failed first release needs to be cleaned up. 