### PR TITLE
SLT-411: Remove quotes around helm values

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -188,7 +188,7 @@ jobs:
                   # Add internal VPN if defined in environment
                   extra_noauthips=""
                   if [[ ! -z "$VPN_IP" ]] ; then
-                    extra_noauthips="--set nginx.noauthips.vpn=\"${VPN_IP}/32\""                    
+                    extra_noauthips="--set nginx.noauthips.vpn=${VPN_IP}/32"
                   fi
                   
                   helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \


### PR DESCRIPTION
Quotes around the value are escaped and passed as part of the value. In this case, the quotes result in a broken VCL configuration file for Varnish.