### PR TITLE
SLT-422: Add support for building and deploying Gatsby sites

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -686,6 +686,23 @@ commands:
             
       - helm-release-information
 
+  gatsby-move-to-subfolder:
+    parameters:
+      subfolder_name:
+        type: string
+      build_folder:
+        type: string
+        default: public
+    steps:
+      - run:
+          name: Move to subfolder
+          command: |
+            mv <<parameters.build_folder>> <<parameters.subfolder_name>>
+            mkdir <<parameters.build_folder>>
+            mv <<parameters.subfolder_name>> <<parameters.build_folder>>/<<parameters.subfolder_name>>
+            mv <<parameters.build_folder>>/<<parameters.subfolder_name>>/.dockerignore <<parameters.build_folder>>/.dockerignore
+            echo '<meta http-equiv="refresh" content="0; URL=<<parameters.subfolder_name>>" />' > <<parameters.build_folder>>/index.html
+
   gatsby-google-cloud-storage-deploy:
     parameters:
       bucket_name:

--- a/orb.yml
+++ b/orb.yml
@@ -707,7 +707,7 @@ commands:
     parameters:
       bucket_name:
         type: string
-      folder:
+      build_folder:
         type: string
         default: public
       static_files:
@@ -717,7 +717,7 @@ commands:
       - run:
           name: Deploy to Google Cloud Storage
           command: |
-            cd <<parameters.folder>>
+            cd <<parameters.build_folder>>
             # We need this rsync mainly to delete obsolete files, but without downtime.
             gsutil -m -h "Cache-Control:public, max-age=300" rsync -d -r . <<parameters.bucket_name>>
             # Make sure all text files can be served gzipped. This is unfortunately not possible with the rsync command.

--- a/orb.yml
+++ b/orb.yml
@@ -685,3 +685,25 @@ commands:
             kubectl get deployment -n "$reponame" -l "release=${RELEASE_NAME}" -o name | xargs -n 1 kubectl rollout status -n "$reponame"
             
       - helm-release-information
+
+  gatsby-google-cloud-storage-deploy:
+    parameters:
+      bucket_name:
+        type: string
+      folder:
+        type: string
+        default: public
+      static_files:
+        type: string
+        default: static
+    steps:
+      - run:
+          name: Deploy to Google Cloud Storage
+          command: |
+            cd <<parameters.folder>>
+            # We need this rsync mainly to delete obsolete files, but without downtime.
+            gsutil -m -h "Cache-Control:public, max-age=300" rsync -d -r . <<parameters.bucket_name>>
+            # Make sure all text files can be served gzipped. This is unfortunately not possible with the rsync command.
+            gsutil -m -h "Cache-Control:public, max-age=300" cp -z html,css,js -r . <<parameters.bucket_name>>
+            # Set a longer cache time for all files in the static folder.
+            gsutil -m setmeta -r -h "Cache-Control:public, max-age=31536000" <<parameters.bucket_name>>/<<parameters.static_files>>

--- a/orb.yml
+++ b/orb.yml
@@ -209,6 +209,79 @@ jobs:
 
             - helm-release-information
 
+
+  simple-build-deploy:
+    executor: <<parameters.executor>>
+    parameters:
+      executor:
+        description: The name of custom executor to use
+        type: executor
+        default: silta
+      codebase-build:
+        type: steps
+        default: []
+      chart_name:
+        type: string
+        default: simple
+      chart_repository:
+        type: string
+        default: https://storage.googleapis.com/charts.wdr.io
+      silta_config:
+        type: string
+        default: "silta/silta.yml"
+      skip-deployment:
+        type: boolean
+        default: false
+      cluster_domain:
+        type: env_var_name
+        default: CLUSTER_DOMAIN
+
+    steps:
+      - checkout
+
+      - steps: <<parameters.codebase-build>>
+
+      - setup_remote_docker
+
+      - gcloud-login
+
+      - docker-login
+
+      - build-docker-image:
+          dockerfile: 'silta/nginx.Dockerfile'
+          path: 'public'
+          identifier: 'nginx'
+
+      - unless:
+          condition: <<parameters.skip-deployment>>
+          steps:
+            - set-release-name
+
+            - helm-cleanup
+
+            - run:
+                name: Deploy helm release
+                command: |
+                  reponame="${CIRCLE_PROJECT_REPONAME,,}"
+
+                  # Add internal VPN if defined in environment
+                  extra_noauthips=""
+                  if [[ ! -z "$VPN_IP" ]] ; then
+                    extra_noauthips="--set nginx.noauthips.vpn=${VPN_IP}/32"
+                  fi
+
+                  helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
+                    --repo '<<parameters.chart_repository>>' \
+                    --set environmentName="$CIRCLE_BRANCH" \
+                    $extra_noauthips \
+                    --set clusterDomain=${<<parameters.cluster_domain>>} \
+                    --set nginx.image=$DOCKER_REPO_HOST/$DOCKER_REPO_PROJ/${CIRCLE_PROJECT_REPONAME,,}-nginx:$nginx_HASH \
+                    --namespace="$reponame" \
+                    --values '<<parameters.silta_config>>' \
+                    --wait
+
+            - helm-release-information
+
 # CircleCI commands
 commands:
   phpcs:


### PR DESCRIPTION
We have quite a few projects using Gatsby, but a lot of them still have too many detailed steps, making it impossible to make changes in a consolidated way.

For an example of what the changes look like for a Gatsby projects, see https://github.com/wunderio/client-fi-altia-spirits-gatsby-larsen/compare/feature/silta-update?expand=1