### PR TITLE
Use vendor/bin/grumphp instead of global one installed into build container

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -13,7 +13,7 @@ grumphp:
         name: grumphp validation
         command: |
           if [ -f grumphp.yml ] && [ -f vendor/bin/grumphp ]; then
-            grumphp run
+            vendor/bin/grumphp run
           fi
 
 drupal-composer-install:


### PR DESCRIPTION
The one in build container doesn't get updated automatically and having different versions might cause issues when tests act differently on local and build context due different versions.