### PR TITLE
Avoid loading cached composer dev dependencies that need to be removed.

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -22,22 +22,28 @@ drupal-composer-install:
       type: boolean
       default: false
   steps:
-    - restore_cache:
-        keys:
-          - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
-          - v1-dependencies-{{ checksum "composer.lock" }}
-
     - when:
+        # Install dev dependencies.
         condition: <<parameters.install-dev-dependencies>>
         steps:
+          # Restore from cache entries with or without dev dependencies.
+          - restore_cache:
+              keys:
+                - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
+                - v1-dependencies-{{ checksum "composer.lock" }}
           - run:
               name: composer install
               command: |
                 composer install -n --prefer-dist --ignore-platform-reqs --optimize-autoloader
 
     - unless:
+        # Don't install dev dependencies.
         condition: <<parameters.install-dev-dependencies>>
         steps:
+          # Only restore from cache entries without dev dependencies.
+          - restore_cache:
+              keys:
+                - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
           - run:
               name: composer install
               command: |


### PR DESCRIPTION
The problematic situation that was happening which we want to avoid:

- Validation job runs, install dev dependencies, some of which are installed via git and eventually modified after installation. The CircleCI cache is then set for the current composer.lock.
- The build job runs. It fails to load the cache based on the current composer.lock without dev dependencies, and then successfully loads the cache with dev dependencies (the one built in the previous step). Running `composer install` would remove dev dependencies, but since they're installed via git and have been modified, we get an error. 