### PR TITLE
SLT-450: If name is too long, truncate it and append a hash.

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -107,6 +107,12 @@ set-release-name:
           # Make sure release name is lowercase without special characters.
           branchname_lower="${CIRCLE_BRANCH,,}"
           release_name="${branchname_lower//[^[:alnum:]]/-}"
+
+          # If name is too long, truncate it and append a hash
+          if [ ${#release_name} -ge 40 ]; then
+            release_name="$(printf "$release_name" | cut -c 1-35)-$(printf "$branchname" | shasum -a 256 | cut -c 1-4 )"
+          fi
+
           silta_environment_name="${CIRCLE_BRANCH,,}"
 
           echo "export RELEASE_NAME='$release_name'" >> "$BASH_ENV"


### PR DESCRIPTION
Tested with the test branch `test/i-cannot-believe-how-long-branch-names-can-really-get-sometimes`, 40 characters is the longest we can get without errors. If the release name is more than 40 characters, we take the first 35 characters followed by a dash and a hash of the full branch name, for a total of 40 characters. 