### PR TITLE
Save _ping.php from dropin-path

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -57,6 +57,7 @@ drupal-composer-install:
           - ./web/themes/contrib
           - ./web/profiles/contrib
           - ./web/libraries
+          - ./web/_ping.php
         key: v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
 
 drupal-docker-build:


### PR DESCRIPTION
I traced back the missing `_ping.php` file:
- composer install installs `wunderio/drupal-ping` package to vendors folder and dropin moves the `_ping.php` file from vendor folder to `web/`
- the `save_cache` saves `vendor/` folder to cache. 
- the `_ping.php` is baked into image and deployed.
- upon the next build, the `restore_cache` is called, but since `vendor/wunderio/drupal-ping` folder exists, `composer install` never triggers the dropin that would copy `_ping.php` to webroot.
And the .gitignore has `_ping.php`, so it can't be put into webroot either.

My proposal is adding `_ping.php` to `save_cache` locations. If the file does not exist, the circleci does not complain about it (tested, see screenshot below):
![Screenshot from 2020-04-14 15-24-55](https://user-images.githubusercontent.com/635571/79226174-992f4f80-7e66-11ea-8109-800cc1e214d4.png)

Including a custom _ping.php instructions could be done via this:
https://github.com/wunderio/drupal-ping/pull/10
