### PR TITLE
Cache key for drupal builds.

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -12,7 +12,7 @@ build-docker-image:
       type: string
     docker-hash-prefix:
       type: string
-      default: v1
+      default: v2
     tag:
       description: If provided, the given tag will be used for the docker image. By default a hash of the codebase (content of the path excluding files matched by .dockerignore) will be created.
       type: string

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -21,6 +21,10 @@ drupal-composer-install:
     install-dev-dependencies:
       type: boolean
       default: false
+    cache-version:
+      description: "Cache key prefix"
+      type: string
+      default: "v2"
   steps:
     - when:
         # Install dev dependencies.
@@ -29,8 +33,8 @@ drupal-composer-install:
           # Restore from cache entries with or without dev dependencies.
           - restore_cache:
               keys:
-                - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
-                - v1-dependencies-{{ checksum "composer.lock" }}
+                - <<parameters.cache-version>>-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
+                - <<parameters.cache-version>>-dependencies-{{ checksum "composer.lock" }}
           - run:
               name: composer install
               command: |
@@ -43,7 +47,7 @@ drupal-composer-install:
           # Only restore from cache entries without dev dependencies.
           - restore_cache:
               keys:
-                - v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
+                - <<parameters.cache-version>>-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
           - run:
               name: composer install
               command: |
@@ -58,7 +62,7 @@ drupal-composer-install:
           - ./web/profiles/contrib
           - ./web/libraries
           - ./web/_ping.php
-        key: v1-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
+        key: <<parameters.cache-version>>-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
 
 drupal-docker-build:
   steps:


### PR DESCRIPTION
Adds parameter for circleci `drupal-composer-install` cache key prefix.
It's set to `v2` now so all existing build cache is invalidated, `vendors` folder does not exist anymore and hence the `_ping.php` is dropped in the webroot again.
Related PR: https://github.com/wunderio/silta-circleci/pull/89 