### PR TITLE
Show live deployment logs

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -109,8 +109,6 @@ drupal-helm-deploy:
             reference_data_override='--set referenceData.skipMount=true'
           fi
 
-          # echo $WHITELISTED_IPS
-
           # Override Database credentials if specified
           if [[ ! -z "$DB_ROOT_PASS" ]] ; then
             db_root_pass_override="--set mariadb.rootUser.password=$DB_ROOT_PASS"

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -102,6 +102,9 @@ drupal-helm-deploy:
         name: Deploy helm release
         no_output_timeout: "15m"
         command: |
+          # Delete existing jobs to prevent getting wrong log output
+          kubectl delete job "$RELEASE_NAME-post-release" -n "$NAMESPACE" --ignore-not-found > /dev/null
+
           # Disable reference data if the required volume is not present.
           reference_volume=$(kubectl get pv | grep --extended-regexp "$NAMESPACE/.*-reference-data") || true
           reference_data_override=''
@@ -127,7 +130,7 @@ drupal-helm-deploy:
             version="--version <<parameters.chart_version>>"
           fi
 
-          output=$((helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
+          helm upgrade --install "$RELEASE_NAME" '<<parameters.chart_name>>' \
             --repo '<<parameters.chart_repository>>' \
             $version \
             --cleanup-on-fail \
@@ -145,22 +148,41 @@ drupal-helm-deploy:
             $reference_data_override \
             --namespace="$NAMESPACE" \
             --values '<<parameters.silta_config>>' \
-            --timeout 15m) 2>&1) || EXIT_CODE=$?
+            --timeout 15m &> helm-output.log &
+          pid=$!
 
-          if [[ $output == *"BackoffLimitExceeded"* ]]; then
-            # Don't show BackoffLimitExceeded, it confuses everyone.
-            echo "The post-release job failed, see log output in the next step below."
-          else
-            echo "$output"
-          fi
+          echo -n "Waiting for containers to start"
 
-          exit $EXIT_CODE
+          TIME_WAITING=0
+          while true; do
+            if kubectl get pod -l job-name="$RELEASE_NAME-post-release" -n "$NAMESPACE" --ignore-not-found | grep  -qE "Running|Completed"; then
+              echo ""
+              echo "Deployment log:"
+              kubectl logs "job/$RELEASE_NAME-post-release" -n "$NAMESPACE" -f --timestamps=true
+            fi
 
-    - run:
-        name: Deployment log
-        when: always
-        command: |
-          kubectl logs "job/$RELEASE_NAME-post-release" -n "$NAMESPACE" -f --timestamps=true
+            # Helm command is complete.
+            if ! ps -p "$pid" > /dev/null; then
+              if grep -q BackoffLimitExceeded helm-output.log ; then
+                # Don't show BackoffLimitExceeded, it confuses everyone.
+                echo "The post-release job failed, see log output above."
+              else
+                echo "Helm output:"
+                cat helm-output.log
+              fi
+              wait $pid
+              break
+            fi
+
+            if [ $TIME_WAITING -gt 120 ]; then
+              echo "Timeout waiting for resources."
+              exit 1
+            fi
+
+            echo -n "."
+            sleep 5
+            TIME_WAITING=$((TIME_WAITING+5))
+          done
 
     - run:
         name: Wait for resources to be ready


### PR DESCRIPTION
The fact that we need to wait for the post-release job to be complete before we can show any logs is definitely not a very nice user experience, as it takes a while to see if anything is happening at all. We also have the issue that long-running updates can result in a CircleCI timeout due to the long time without any output. 

The logic is a bit twisted, but here's my attempt at describing it:

- Run `helm install` in the background.
- If a pod exists for the post-release job, get its logs until the job is complete
- If the background command completed, show its output (also continue handling the "BackoffLimitExceeded" case)
- If nothing happens for over two minutes, communicate a timeout. 

Here are test builds that show the following behavior:
- Successful build: https://circleci.com/gh/wunderio/drupal-project-k8s/8792
- The post-release job failed: https://circleci.com/gh/wunderio/drupal-project-k8s/8791 (The postupgrade command was overridde to `echo "waiting for five seconds." && sleep 5 && exit 1`
- The upgrade failed due to invalid k8s configuration: https://circleci.com/gh/wunderio/drupal-project-k8s/8778

(Note that the "Deployment log" step is gone, the deployment is now displayed in the "Deploy helm release" step).