### PR TITLE
Return 0 when the post-release resource is not found yet

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -159,7 +159,7 @@ drupal-helm-deploy:
             if [ $LOGS_SHOWN == false ] && kubectl get pod -l job-name="$RELEASE_NAME-post-release" -n "$NAMESPACE" --ignore-not-found | grep  -qE "Running|Completed" ; then
               echo ""
               echo "Deployment log:"
-              kubectl logs "job/$RELEASE_NAME-post-release" -n "$NAMESPACE" -f --timestamps=true
+              kubectl logs "job/$RELEASE_NAME-post-release" -n "$NAMESPACE" -f --timestamps=true || true
               LOGS_SHOWN=true
             fi
 


### PR DESCRIPTION
This should fix the race condition when the helm upgrade has not created the post-install resource yet, but the log viewer iterator wants an output from it.

```
$ kubectl logs "job/nonexistent-post-releases" -n "namespace" -f --timestamps=true
Error from server (NotFound): jobs.batch "nonexistent-post-release" not found
ubuntu@gke_client:~/temp/kubernetes-ftp$ echo $?
1
```

```
$ kubectl logs "job/nonexistent-post-releases" -n "namespace" -f --timestamps=true || true
Error from server (NotFound): jobs.batch "nonexistent-post-release" not found
ubuntu@gke_client:~/temp/kubernetes-ftp$ echo $?
0
```