### PR TITLE
Changing the image prefix to pick up shell container change

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -12,7 +12,7 @@ build-docker-image:
       type: string
     docker-hash-prefix:
       type: string
-      default: v2
+      default: v3
     tag:
       description: If provided, the given tag will be used for the docker image. By default a hash of the codebase (content of the path excluding files matched by .dockerignore) will be created.
       type: string


### PR DESCRIPTION
Accept this only after:
1. https://github.com/wunderio/drupal-project-k8s/pull/228 is merged into charts repo
2. The drupal-shell image is tagged with 0.1.x and [built in docker hub](https://hub.docker.com/repository/docker/wunderio/drupal-shell/builds).