### PR TITLE
Failed pod detection

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -104,7 +104,7 @@ drupal-helm-deploy:
         no_output_timeout: "15m"
         command: |
           #Detect pods in FAILED state
-          function failing_pods() {
+          function show_failing_pods() {
             failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME" -n "$NAMESPACE" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+'c)
             if [[ ! -z "$failed_pods" ]] ; then
               echo "Failing pods:"
@@ -180,14 +180,14 @@ drupal-helm-deploy:
             fi
 
             echo ""; echo ""
-            if failing_pods; then
+            if show_failing_pods; then
               exit 1
             fi
             # Helm command is complete.
             if ! ps -p "$pid" > /dev/null; then
               if grep -q BackoffLimitExceeded helm-output.log ; then
                 # Don't show BackoffLimitExceeded, it confuses everyone.
-                failing_pods
+                show_failing_pods
                 echo "The post-release job failed, see log output above."
               else
                 echo "Helm output:"
@@ -199,7 +199,7 @@ drupal-helm-deploy:
 
             if [ $TIME_WAITING -gt 120 ]; then
               echo "Timeout waiting for resources."
-              failing_pods
+              show_failing_pods
               exit 1
             fi
 

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -109,9 +109,11 @@ drupal-helm-deploy:
             if [[ ! -z "$failed_pods" ]] ; then
               echo "Failing pods:"
               echo "$failed_pods"
-              true
+              echo ""
+              echo "Please check logs for the pods above"
+              false
             fi
-            false
+            true
           }
           
           # Delete existing jobs to prevent getting wrong log output
@@ -177,6 +179,7 @@ drupal-helm-deploy:
               LOGS_SHOWN=true
             fi
 
+            echo ""; echo ""
             if failing_pods; then
               exit 1
             fi

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -106,12 +106,13 @@ drupal-helm-deploy:
           #Detect pods in FAILED state
           function failing_pods() {
             failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME" -n "$NAMESPACE" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+'c)
-
-          if [[ ! -z "$failed_pods" ]] ; then
-            echo "Failing pods:"
-            echo "$failed_pods"
-          fi
-
+            echo "failed pods function"
+            if [[ ! -z "$failed_pods" ]] ; then
+              echo "Failing pods:"
+              echo "$failed_pods"
+              return 1
+            fi
+            return 0
           }
           
           # Delete existing jobs to prevent getting wrong log output
@@ -177,6 +178,9 @@ drupal-helm-deploy:
               LOGS_SHOWN=true
             fi
 
+            if [ failing_pods -ne 0 ]; then
+              exit $?
+            fi
             # Helm command is complete.
             if ! ps -p "$pid" > /dev/null; then
               if grep -q BackoffLimitExceeded helm-output.log ; then

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -178,8 +178,10 @@ drupal-helm-deploy:
               LOGS_SHOWN=true
             fi
 
-            if [ failing_pods -ne 0 ]; then
-              exit $?
+            failing_pods
+            result=$?
+            if [ $result -ne 0 ]; then
+              exit $result
             fi
             # Helm command is complete.
             if ! ps -p "$pid" > /dev/null; then

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -105,7 +105,7 @@ drupal-helm-deploy:
         command: |
           #Detect pods in FAILED state
           function failing_pods() {
-            failed_pods=$(kubectl get pod -l "release=feature-slt-451" -n "drupal-project-k8s" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+'c)
+            failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME" -n "$NAMESPACE" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+'c)
 
           if [[ ! -z "$failed_pods" ]] ; then
             echo "Failing pods:"

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -103,6 +103,17 @@ drupal-helm-deploy:
         name: Deploy helm release
         no_output_timeout: "15m"
         command: |
+          #Detect pods in FAILED state
+          function failing_pods() {
+            failed_pods=$(kubectl get pod -l "release=feature-slt-451" -n "drupal-project-k8s" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+'c)
+
+          if [[ ! -z "$failed_pods" ]] ; then
+            echo "Failing pods:"
+            echo "$failed_pods"
+          fi
+
+          }
+          
           # Delete existing jobs to prevent getting wrong log output
           kubectl delete job "$RELEASE_NAME-post-release" -n "$NAMESPACE" --ignore-not-found > /dev/null
 
@@ -170,6 +181,7 @@ drupal-helm-deploy:
             if ! ps -p "$pid" > /dev/null; then
               if grep -q BackoffLimitExceeded helm-output.log ; then
                 # Don't show BackoffLimitExceeded, it confuses everyone.
+                failing_pods
                 echo "The post-release job failed, see log output above."
               else
                 echo "Helm output:"
@@ -181,6 +193,7 @@ drupal-helm-deploy:
 
             if [ $TIME_WAITING -gt 120 ]; then
               echo "Timeout waiting for resources."
+              failing_pods
               exit 1
             fi
 

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -106,13 +106,12 @@ drupal-helm-deploy:
           #Detect pods in FAILED state
           function failing_pods() {
             failed_pods=$(kubectl get pod -l "release=$RELEASE_NAME" -n "$NAMESPACE" --no-headers | grep -Ev '([0-9]+)/\1' | grep -Eo '^[^ ]+'c)
-            echo "failed pods function"
             if [[ ! -z "$failed_pods" ]] ; then
               echo "Failing pods:"
               echo "$failed_pods"
-              return 1
+              true
             fi
-            return 0
+            false
           }
           
           # Delete existing jobs to prevent getting wrong log output
@@ -178,10 +177,8 @@ drupal-helm-deploy:
               LOGS_SHOWN=true
             fi
 
-            failing_pods
-            result=$?
-            if [ $result -ne 0 ]; then
-              exit $result
+            if failing_pods; then
+              exit 1
             fi
             # Helm command is complete.
             if ! ps -p "$pid" > /dev/null; then

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -179,10 +179,6 @@ drupal-helm-deploy:
               LOGS_SHOWN=true
             fi
 
-            echo ""; echo ""
-            if show_failing_pods; then
-              exit 1
-            fi
             # Helm command is complete.
             if ! ps -p "$pid" > /dev/null; then
               if grep -q BackoffLimitExceeded helm-output.log ; then

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -111,9 +111,9 @@ drupal-helm-deploy:
               echo "$failed_pods"
               echo ""
               echo "Please check logs for the pods above"
-              false
+              true
             fi
-            true
+            false
           }
           
           # Delete existing jobs to prevent getting wrong log output


### PR DESCRIPTION
Outputs the list pods which have failed during deployment.

To force a pod in failed state, one can set .dockerfile execution to "ENTRYPOINT exit 1"