### PR TITLE
SLT-385: mariadb update

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -107,11 +107,11 @@ set-release-name:
 
           # Make sure release name is lowercase without special characters.
           branchname_lower="${CIRCLE_BRANCH,,}"
-          release_name="${branchname_lower//[^[:alnum:]]/-}"
+          export release_name="${branchname_lower//[^[:alnum:]]/-}"
 
           # If name is too long, truncate it and append a hash
           if [ ${#release_name} -ge 40 ]; then
-            release_name="$(printf "$release_name" | cut -c 1-35)-$(printf "$branchname_lower" | shasum -a 256 | cut -c 1-4 )"
+            export release_name="$(printf "$release_name" | cut -c 1-35)-$(printf "$branchname_lower" | shasum -a 256 | cut -c 1-4 )"
           fi
 
           silta_environment_name="${CIRCLE_BRANCH,,}"
@@ -121,6 +121,14 @@ set-release-name:
           echo "export SILTA_ENVIRONMENT_NAME='$silta_environment_name'" >> "$BASH_ENV"
 
           echo "The release name for this branch is \"$release_name\" in the \"$namespace\" namespace"
+
+          if helm status -n $namespace $release_name > /dev/null  2>&1
+          then
+            current_chart_version=$(helm list --all -n $namespace -o json | jq -r '.[] | select(.name == env.release_name) | .chart ')
+            echo "export CURRENT_CHART_VERSION='$current_chart_version'" >> "$BASH_ENV"
+
+            echo "There is an existing chart with version $current_chart_version"
+          fi
 
 gcloud-login:
   steps:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -107,11 +107,11 @@ set-release-name:
 
           # Make sure release name is lowercase without special characters.
           branchname_lower="${CIRCLE_BRANCH,,}"
-          export release_name="${branchname_lower//[^[:alnum:]]/-}"
+          release_name="${branchname_lower//[^[:alnum:]]/-}"
 
           # If name is too long, truncate it and append a hash
           if [ ${#release_name} -ge 40 ]; then
-            export release_name="$(printf "$release_name" | cut -c 1-35)-$(printf "$branchname_lower" | shasum -a 256 | cut -c 1-4 )"
+            release_name="$(printf "$release_name" | cut -c 1-35)-$(printf "$branchname_lower" | shasum -a 256 | cut -c 1-4 )"
           fi
 
           silta_environment_name="${CIRCLE_BRANCH,,}"
@@ -122,9 +122,9 @@ set-release-name:
 
           echo "The release name for this branch is \"$release_name\" in the \"$namespace\" namespace"
 
-          if helm status -n $namespace $release_name > /dev/null  2>&1
+          if helm status -n "$namespace" "$release_name" > /dev/null  2>&1
           then
-            current_chart_version=$(helm list --all -n $namespace -o json | jq -r '.[] | select(.name == env.release_name) | .chart ')
+            current_chart_version=$(helm history -n "$namespace" "$release_name" --max 1 --output json | jq -r '.[].chart')
             echo "export CURRENT_CHART_VERSION='$current_chart_version'" >> "$BASH_ENV"
 
             echo "There is an existing chart with version $current_chart_version"

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -102,9 +102,9 @@ drupal-helm-deploy:
         command: |
           function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
 
-          if [[ -n "$CURRENT_CHART_VERSION" ]] && [[ $CURRENT_CHART_VERSION = drupal-* ]]
+          if [[ -n "$CURRENT_CHART_VERSION" ]] && [[ "$CURRENT_CHART_VERSION" = drupal-* ]]
           then
-            if version_lt "$CURRENT_CHART_VERSION" drupal-0.3.43
+            if version_lt "$CURRENT_CHART_VERSION" "drupal-0.3.43"
             then
               echo "Recreating statefulset for Mariadb subchart update to 7.x."
               kubectl delete statefulset --cascade=false "$RELEASE_NAME-mariadb" -n "$NAMESPACE"

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -98,6 +98,20 @@ drupal-helm-deploy:
   steps:
     - helm-cleanup
     - run:
+        name: Special updates
+        command: |
+          function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
+
+          if [[ -n "$CURRENT_CHART_VERSION" ]];
+          then
+            if version_lt "$CURRENT_CHART_VERSION" drupal-0.3.43
+            then
+              echo "Recreating statefulset for Mariadb subchart update to 7.x."
+              kubectl delete statefulset --cascade=false "$RELEASE_NAME-mariadb" -n "$NAMESPACE"
+            fi
+          fi
+
+    - run:
         name: Deploy helm release
         no_output_timeout: "15m"
         command: |

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -102,7 +102,7 @@ drupal-helm-deploy:
         command: |
           function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
 
-          if [[ -n "$CURRENT_CHART_VERSION" ]];
+          if [[ -n "$CURRENT_CHART_VERSION" ]] && [[ $CURRENT_CHART_VERSION = drupal-* ]]
           then
             if version_lt "$CURRENT_CHART_VERSION" drupal-0.3.43
             then


### PR DESCRIPTION
For major updates of subcharts it can be required to delete statefulsets while preserving existing pods using the `--cascade=false` option, but of course we don't want to do that for every deployment. We have seen that doing this manually leads to confusion among developers and additional work. This PR automates the process, only deleting the statefulset when the existing chart is older than drupal-0.3.43. This goes together with the proposed update in https://github.com/wunderio/drupal-project-k8s/pull/240.