### PR TITLE
SLT-537: Add a possibility to provide a suffix for the release name.

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -85,13 +85,22 @@ docker-login:
           fi
 
 silta-setup:
+  parameters:
+    release-suffix:
+      type: string
+      default: ''
   steps:
     - setup_remote_docker
     - docker-login
     - gcloud-login
-    - set-release-name
+    - set-release-name:
+        release-suffix: '<<parameters.release-suffix>>'
 
 set-release-name:
+  parameters:
+    release-suffix:
+      type: string
+      default: ''
   steps:
     - run:
         name: Set release name
@@ -116,6 +125,10 @@ set-release-name:
           # If name is too long, truncate it and append a hash
           if [ ${#release_name} -ge 40 ]; then
             release_name="$(printf "$release_name" | cut -c 1-35)-$(printf "$branchname_lower" | shasum -a 256 | cut -c 1-4 )"
+          fi
+
+          if [[ -n '<<parameters.release-suffix>>' ]]; then
+            release_name="${release_name}-<<parameters.release-suffix>>"
           fi
 
           silta_environment_name="${CIRCLE_BRANCH,,}"

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -89,6 +89,9 @@ drupal-build-deploy:
     cluster_domain:
       type: env_var_name
       default: CLUSTER_DOMAIN
+    release-suffix:
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -102,7 +105,8 @@ drupal-build-deploy:
               steps:
                 - decrypt-files:
                     files: <<parameters.decrypt_files>>
-          - silta-setup
+          - silta-setup:
+              release-suffix: '<<parameters.release-suffix>>'
           - drupal-docker-build
           - steps: <<parameters.pre-release>>
           - drupal-helm-deploy:

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -31,12 +31,16 @@ frontend-build-deploy:
           path: '.'
           identifier: 'node'
           docker-hash-prefix: v6
+    release-suffix:
+      type: string
+      default: ''
   steps:
     - checkout
 
     - steps: <<parameters.codebase-build>>
 
-    - silta-setup
+    - silta-setup:
+        release-suffix: '<<parameters.release-suffix>>'
 
     - steps: <<parameters.image_build_steps>>
 

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -29,6 +29,9 @@ simple-build-deploy:
     build_folder:
       type: string
       default: public
+    release-suffix:
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:
@@ -36,7 +39,8 @@ simple-build-deploy:
 
     - steps: <<parameters.codebase-build>>
 
-    - silta-setup
+    - silta-setup:
+        release-suffix: '<<parameters.release-suffix>>'
 
     - build-docker-image:
         dockerfile: 'silta/nginx.Dockerfile'


### PR DESCRIPTION
We sometimes want to deploy multiple releases from the same repository, for example a Drupal site with a separate storybook deployed as a static site. At the moment, the would two conflict because of the same release names. This PR adds a configurable suffix that avoids conflicts.