### PR TITLE
Allow overriding nginx docker image build context.

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -90,7 +90,8 @@ silta-setup:
       type: string
       default: ''
   steps:
-    - setup_remote_docker
+    - setup_remote_docker:
+        version: 19.03.8
     - set-up-socks-proxy
     - docker-login
     - gcloud-login

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -91,6 +91,7 @@ silta-setup:
       default: ''
   steps:
     - setup_remote_docker:
+        # Note: default Docker version is 17.09. Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
         version: 19.03.8
     - set-up-socks-proxy
     - docker-login

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -66,14 +66,14 @@ drupal-composer-install:
 
 drupal-docker-build:
   parameters:
-    build_context:
+    nginx_build_context:
       type: string
       default: "web"
       description: "Path to be used as build context for Nginx image."
   steps:
     - build-docker-image:
         dockerfile: silta/nginx.Dockerfile
-        path: <<parameters.build_context>>
+        path: <<parameters.nginx_build_context>>
         identifier: nginx
         docker-hash-prefix: v5
 

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -65,10 +65,14 @@ drupal-composer-install:
         key: <<parameters.cache-version>>-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
 
 drupal-docker-build:
+  parameters:
+    nginx_build_context:
+      type: string
+      default: "web"
   steps:
     - build-docker-image:
         dockerfile: silta/nginx.Dockerfile
-        path: web
+        path: <<parameters.nginx_build_context>>
         identifier: nginx
         docker-hash-prefix: v5
 

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -66,9 +66,10 @@ drupal-composer-install:
 
 drupal-docker-build:
   parameters:
-    nginx_build_context:
+    build_context:
       type: string
       default: "web"
+      description: "Path to be used as build context for Nginx image."
   steps:
     - build-docker-image:
         dockerfile: silta/nginx.Dockerfile

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -73,7 +73,7 @@ drupal-docker-build:
   steps:
     - build-docker-image:
         dockerfile: silta/nginx.Dockerfile
-        path: <<parameters.nginx_build_context>>
+        path: <<parameters.build_context>>
         identifier: nginx
         docker-hash-prefix: v5
 


### PR DESCRIPTION
By default the web/ folder is passed as a build context to the nginx image. This prevent's using include files stored outside the web/ in nginx configmap.
