### PR TITLE
Adds analyse job, sonar executor.

### DIFF
--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -6,3 +6,6 @@ executors:
   silta:
     docker:
       - image: wunderio/silta-circleci:v0.1
+  sonar:
+    docker:
+      - image: wunderio/circleci-sonar-scanner:latest

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -1,3 +1,27 @@
+analyze:
+  executor: <<parameters.executor>>
+  parameters:
+    executor:
+      description: The name of custom executor to use
+      type: executor
+      default: sonar
+    sonar_host:
+      type: env_var_name
+      default: SONAR_HOST
+    sonar_token:
+      type: env_var_name
+      default: SONAR_TOKEN
+    sources:
+      type: string
+      default: "web/modules,web/themes,src"
+  steps:
+    - checkout
+    - run: >-
+        sonar-scanner -Dsonar.host.url='<<parameters.sonar_host>>'
+        -Dsonar.login='<<parameters.sonar_token>>'
+        -Dsonar.projectKey="${CIRCLE_PROJECT_REPONAME,,}"
+        -Dsonar.sources='<<parameters.sources>>'
+
 drupal-validate:
   executor: <<parameters.executor>>
   parameters:

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -17,8 +17,8 @@ analyze:
   steps:
     - checkout
     - run: >-
-        sonar-scanner -Dsonar.host.url='<<parameters.sonar_host>>'
-        -Dsonar.login='<<parameters.sonar_token>>'
+        sonar-scanner -Dsonar.host.url=${'<<parameters.sonar_host>>'}
+        -Dsonar.login==${'<<parameters.sonar_token>>'}
         -Dsonar.projectKey="${CIRCLE_PROJECT_REPONAME,,}"
         -Dsonar.sources='<<parameters.sources>>'
 

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -7,7 +7,7 @@ analyze:
       default: sonar
     sources:
       type: string
-      default: "web/modules,web/themes,src"
+      default: "web/modules,web/themes"
   steps:
     - checkout
     - run: >-

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -12,7 +12,7 @@ analyze:
     - checkout
     - run: >-
         sonar-scanner -Dsonar.host.url="${SONAR_HOST}"
-        -Dsonar.login=="${SONAR_TOKEN}"
+        -Dsonar.login="${SONAR_TOKEN}"
         -Dsonar.projectKey="${CIRCLE_PROJECT_REPONAME,,}"
         -Dsonar.sources='<<parameters.sources>>'
 

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -5,20 +5,14 @@ analyze:
       description: The name of custom executor to use
       type: executor
       default: sonar
-    sonar_host:
-      type: env_var_name
-      default: SONAR_HOST
-    sonar_token:
-      type: env_var_name
-      default: SONAR_TOKEN
     sources:
       type: string
       default: "web/modules,web/themes,src"
   steps:
     - checkout
     - run: >-
-        sonar-scanner -Dsonar.host.url=${'<<parameters.sonar_host>>'}
-        -Dsonar.login==${'<<parameters.sonar_token>>'}
+        sonar-scanner -Dsonar.host.url="${SONAR_HOST}"
+        -Dsonar.login=="${SONAR_TOKEN}"
         -Dsonar.projectKey="${CIRCLE_PROJECT_REPONAME,,}"
         -Dsonar.sources='<<parameters.sources>>'
 


### PR DESCRIPTION
**Adds `analyse` job and sonar executor.**

Purpose of this:
- Allow standardised way to analyse  projects with sonar.

How it works:
Add to project circleci/config.yml:
```workflows:
  version: 2
  commit:
    jobs:
      - silta/analyze:
          name: analyze
          context: analyze
```