### PR TITLE
HTTP Proxy support

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -227,8 +227,6 @@ set-up-socks-proxy:
         command: |
           if [[ -n "$TUNNEL_PRIVATE_KEY" ]]; then
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
-          else
-            echo "Private key is not supplied. Skipping..."
           fi    
     - run:
         name: Open up a tunnel
@@ -239,6 +237,6 @@ set-up-socks-proxy:
             gcloud config set proxy/type socks5
             gcloud config set proxy/address 127.0.0.1
             gcloud config set proxy/port 1337
-          else
-            echo "No proxy host defined. Skipping..."
+            echo "Proxy is ready for outgoing connections"
           fi
+

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -218,3 +218,26 @@ decrypt-files:
               chmod a+r "$file"
             done
           fi
+
+set-up-socks-proxy:
+  steps:
+    - run:
+        name: Add SSH private-key
+        command: |
+          if [[ -n "$TUNNEL_PRIVATE_KEY" ]]; then
+            echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
+          else
+            echo "Private key is not supplied. Skipping..."
+          fi    
+    - run:
+        name: Open up a tunnel
+        command: |
+          if [[ -n "$TUNNEL_USER_HOST" ]]; then
+            ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
+            echo 'export HTTPS_PROXY=socks5://localhost:1337' >> $BASH_ENV
+            gcloud config set proxy/type socks5
+            gcloud config set proxy/address 127.0.0.1
+            gcloud config set proxy/port 1337
+          else
+            echo "No proxy host defined. Skipping..."
+          fi

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -91,6 +91,7 @@ silta-setup:
       default: ''
   steps:
     - setup_remote_docker
+    - set-up-socks-proxy
     - docker-login
     - gcloud-login
     - set-release-name:


### PR DESCRIPTION
Added support for tunneling deployment traffic through an SSH host.
Enables CircleCI deployments to "have" fixed outgoing IP.

Development was done in https://github.com/wunderio/drupal-project-k8s/tree/feature/deployment-via-socks5 