### PR TITLE
Improved failed release filter

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -166,7 +166,7 @@ helm-cleanup:
     - run:
         name: Clean up failed Helm releases
         command: |
-          failed_revision=$(helm list -n "$NAMESPACE" --failed --pending --filter="\b($RELEASE_NAME)\b" | tail -1 | cut -f3)
+          failed_revision=$(helm list -n "$NAMESPACE" --failed --pending --filter="(\s|^)($RELEASE_NAME)(\s|$)" | tail -1 | cut -f3)
 
           if [[ "$failed_revision" -eq 1 ]]; then
             # Remove any existing post-release hook, since it's technically not part of the release.


### PR DESCRIPTION
Current failed release filter assumes the hyphen is word boundary. Because of this, some deployments fail with this error (there is `develop-sb` release and `develop` is being deployed -
```
Error: uninstall: Release not loaded: develop: release: not found
```
Filter using `\b` -
```
$ helm list -n "[namespace]" --failed --pending --filter="\b(develop)\b" | tail -1 
develop-sb	[namespace]	1       	2020-09-08 18:04:02.193848467 +0000 UTC	pending-install	simple-0.2.6

$ helm list -n "[namespace]" --failed --pending --filter="\b(develop-sb)\b" | tail -1 
develop-sb	[namespace]	1       	2020-09-08 18:04:02.193848467 +0000 UTC	pending-install	simple-0.2.6
```
Following filter adjustment should fix the issue:
```
$ helm list -n "[namespace]" --failed --pending --filter="(\s|^)(develop)(\s|$)" | tail -1 
(empty result)

$ helm list -n "[namespace]" --failed --pending --filter="(\s|^)(develop-sb)(\s|$)" | tail -1 
develop-sb	[namespace]	1       	2020-09-08 18:04:02.193848467 +0000 UTC	pending-install	simple-0.2.6

```