### PR TITLE
Make the resource class configurable for "simple" builds

### DIFF
--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -1,5 +1,6 @@
 simple-build-deploy:
   executor: <<parameters.executor>>
+  resource_class: <<parameters.resource_class>>
   parameters:
     executor:
       description: The name of custom executor to use
@@ -32,6 +33,10 @@ simple-build-deploy:
     release-suffix:
       type: string
       default: ''
+    resource_class:
+      type: string
+      # Medium is the default when not specified.
+      default: medium
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:


### PR DESCRIPTION
Some Gatsby builds are quite resource intensive, especially regarding image manipulation. For these cases, it makes sense to use a larger CircleCI resource image.

Usage for a job in your .circleci/config.yaml:
```
      - silta/simple-build-deploy:
          resource_class: large
          [...]
```