### PR TITLE
Remove code quality tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM circleci/php:7.3.19-cli-node
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
 
-# Install drush, prestissimo and code-quality.
-RUN composer global require drush/drush-launcher hirak/prestissimo wunderio/code-quality \
+# Install drush and prestissimo.
+RUN composer global require drush/drush-launcher hirak/prestissimo \
   && composer clearcache
 
 # Install vim based on popular demand.


### PR DESCRIPTION
Removes code quality tool as it is not ever used. 

Code quality tool is used only if project requires it and is called from vendor/bin of project.
Keeping it on image means that it is out of date and not project specific version is installed.

Features:

- Removes wunderio/code-quality from docker image.