### PR TITLE
Add step to post release notes to Github PR comments

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -206,10 +206,10 @@ helm-release-information:
     - run:
         name: Post release info to Github
         command: |
-          if [ ! -z $GITHUB_TOKEN ]
+          if [ -n "$GITHUB_TOKEN" ]
           then
             RELEASE_NOTES=`helm -n "$NAMESPACE" get notes "$RELEASE_NAME"`
-            if [ -z $CIRCLE_PR_NUMBER ]
+            if [ -z "$CIRCLE_PR_NUMBER" ]
             then
               CIRCLE_PR_NUMBER="${CIRCLE_PULL_REQUEST//[^0-9]/}"
             fi

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -203,6 +203,20 @@ helm-release-information:
         command: |
           # Display only the part following NOTES from the helm status.
           helm -n "$NAMESPACE" get notes "$RELEASE_NAME"
+    - run:
+        name: Post release info to Github
+        command: |
+          if [ ! -z $GITHUB_TOKEN ]
+          then
+            RELEASE_NOTES=`helm -n "$NAMESPACE" get notes "$RELEASE_NAME"`
+            if [ -z $CIRCLE_PR_NUMBER ]
+            then
+              CIRCLE_PR_NUMBER="${CIRCLE_PULL_REQUEST//[^0-9]/}"
+            fi
+            GITHUB_API_URL="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$CIRCLE_PR_NUMBER/comments"
+            FORMATTED_NOTES=$(echo "$RELEASE_NOTES" | sed 's/\\/\\\\/g' | sed 's/"/\\\"/g' | sed 's/\$/\\n/g' | sed 's/\//\\\//g')
+            curl -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -X POST -d '{"body": "'"${FORMATTED_NOTES//$'\n'/'\n'}"'"}' $GITHUB_API_URL
+          fi
 
 decrypt-files:
   parameters:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -215,7 +215,7 @@ helm-release-information:
             fi
             GITHUB_API_URL="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$CIRCLE_PR_NUMBER/comments"
             FORMATTED_NOTES=$(echo "$RELEASE_NOTES" | sed 's/\\/\\\\/g' | sed 's/"/\\\"/g' | sed 's/\$/\\n/g' | sed 's/\//\\\//g')
-            curl -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -X POST -d '{"body": "<details><summary>Release notes</summary>'"${FORMATTED_NOTES//$'\n'/'\n'}"'</details>"}' $GITHUB_API_URL
+            curl -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -X POST -d '{"body": "<details><summary>Release notes for '$RELEASE_NAME'</summary>'"${FORMATTED_NOTES//$'\n'/'\n'}"'</details>"}' $GITHUB_API_URL
           fi
 
 decrypt-files:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -215,7 +215,7 @@ helm-release-information:
             fi
             GITHUB_API_URL="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/issues/$CIRCLE_PR_NUMBER/comments"
             FORMATTED_NOTES=$(echo "$RELEASE_NOTES" | sed 's/\\/\\\\/g' | sed 's/"/\\\"/g' | sed 's/\$/\\n/g' | sed 's/\//\\\//g')
-            curl -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -X POST -d '{"body": "'"${FORMATTED_NOTES//$'\n'/'\n'}"'"}' $GITHUB_API_URL
+            curl -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -X POST -d '{"body": "<details><summary>Release notes</summary>'"${FORMATTED_NOTES//$'\n'/'\n'}"'</details>"}' $GITHUB_API_URL
           fi
 
 decrypt-files:


### PR DESCRIPTION
This came up during the discussions with JS guild and comparing Silta with platforms like Vercel and one of the intriguing feature of Vercel that was mentioned was the ability to see deployed environment information straight from the Github instead of having to go to CI.
This is initial proof of concept to enable posting the same release notes that are displayed at the bottom of the CircleCI job log to the comments of the PR that initiated the build.
Requires creating personal Github OAuth token with `repo` scope and adding that to project specific environment variables in CircleCI.
To see it in action you can check https://github.com/wunderio/client-fi-fortum-indiana/pull/678