### PR TITLE
Upgrade PHP to 7.4.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/php:7.3.19-cli-node
+FROM circleci/php:7.4.12-cli-node
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"


### PR DESCRIPTION
Active Support for PHP 7.3 ends on December 6 2020 and I think now is a good time to start upgrading the infrastructure to the most recent major version of PHP. 

I don't know enough about your infrastructure to know if it is safe to upgrade just like this, or if we should create a separate branch or our own 7.4-based Dockerfile? 