### PR TITLE
Expose BUILDER_BASE_IMAGE as arg, allow overriding base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM circleci/php:7.3.19-cli-node
+ARG BUILDER_BASE_IMAGE=circleci/php:7.3.19-cli-node
+
+FROM ${BUILDER_BASE_IMAGE}
 
 # Make composer packages executable.
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"


### PR DESCRIPTION
Allows overriding base image

Usage example:
```
executors:
  silta-node-14:
    docker:
      - image: wunderio/silta-circleci:latest
        environment:
          BUILDER_BASE_IMAGE: circleci/php:7.3.23-cli-node

workflows:
  version: 2
      - silta/drupal-build-deploy: &build-deploy
          name: build-deploy

          # Use the custom executor that provides node 14.x
          executor: silta-node-14
          (..)
```