### PR TITLE
Aws tools added to builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILDER_BASE_IMAGE}
 ENV PATH="/home/circleci/.composer/vendor/bin:${PATH}"
 
 # Install drush and prestissimo.
-RUN composer global require drush/drush-launcher hirak/prestissimo \
+RUN composer global require drush/drush-launcher:^0.8.0 hirak/prestissimo \
   && composer clearcache
 
 # Install vim based on popular demand.
@@ -19,6 +19,12 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && sudo apt-get update && sudo apt-get install google-cloud-sdk=${GCLOUD_VERSION} kubectl \
   && sudo apt-get clean
+
+# Install AWS cli and aws-iam-authenticator
+RUN sudo apt-get install -y awscli git python3 \
+  && curl -o /tmp/aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/aws-iam-authenticator \
+  && chmod +x /tmp/aws-iam-authenticator \ 
+  && sudo mv /tmp/aws-iam-authenticator /bin/aws-iam-authenticator
 
 # Install Helm 3
 ENV HELM_VERSION v3.2.4


### PR DESCRIPTION
- Aws tools added to builder image 
- drush-launcher pinned to 0.8.0 since the installation of last release is seemingly broken