### PR TITLE
few fixes

### DIFF
--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -5,7 +5,7 @@ description: "A collection of CircleCI tools used by the Silta hosting infrastru
 executors:
   silta:
     docker:
-      - image: wunderio/silta-circleci:v0.1
+      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
   sonar:
     docker:
       - image: wunderio/circleci-sonar-scanner:latest

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -243,11 +243,6 @@ helm-cleanup:
 helm-release-information:
   steps:
     - run:
-        name: Release information
-        command: |
-          # Display only the part following NOTES from the helm status.
-          helm -n "$NAMESPACE" get notes "$RELEASE_NAME"
-    - run:
         name: Post release info to Github
         command: |
           if [ -n "$GITHUB_TOKEN" ]
@@ -261,6 +256,11 @@ helm-release-information:
             FORMATTED_NOTES=$(echo "$RELEASE_NOTES" | sed 's/\\/\\\\/g' | sed 's/"/\\\"/g' | sed 's/\$/\\n/g' | sed 's/\//\\\//g')
             curl -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -X POST -d '{"body": "<details><summary>Release notes for '$RELEASE_NAME'</summary>'"${FORMATTED_NOTES//$'\n'/'\n'}"'</details>"}' $GITHUB_API_URL
           fi
+    - run:
+        name: Release information
+        command: |
+          # Display only the part following NOTES from the helm status.
+          helm -n "$NAMESPACE" get notes "$RELEASE_NAME"
 
 decrypt-files:
   parameters:


### PR DESCRIPTION
1. Circleci image repo change (references identical image from silta-images repository). Docker hub images are not built automatically anymore, this will also help figuring out component versions for the builder image.
2. helm release info step order change (release info goes last, like before)