### PR TITLE
Remove Helm releases' pending state

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -240,6 +240,14 @@ helm-cleanup:
             done
           fi
 
+
+          pending_release=$(helm list -n "$NAMESPACE" --pending --filter="(\s|^)($RELEASE_NAME)(\s|$)"| tail -1 | cut -f1)
+
+          if [[ "$pending_release" == "$RELEASE_NAME" ]]; then
+            secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-upgrade,name=bugfix-helm-pending --namespace drupal-project-k8s | awk '{print $1}' | grep -v NAME)
+            echo "$secret_to_delete"
+          fi
+
 helm-release-information:
   steps:
     - run:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -240,12 +240,12 @@ helm-cleanup:
             done
           fi
 
-
+          #Workaround for previous release stuck in pending state
           pending_release=$(helm list -n "$NAMESPACE" --pending --filter="(\s|^)($RELEASE_NAME)(\s|$)"| tail -1 | cut -f1)
 
           if [[ "$pending_release" == "$RELEASE_NAME" ]]; then
-            secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-upgrade,name=bugfix-helm-pending --namespace drupal-project-k8s | awk '{print $1}' | grep -v NAME)
-            echo "$secret_to_delete"
+            secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-upgrade,name="$RELEASE_NAME" -n "$NAMESPACE" | awk '{print $1}' | grep -v NAME)
+            kubectl describe secret -n "$NAMESPACE" "$secret_to_delete"
           fi
 
 helm-release-information:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -245,7 +245,7 @@ helm-cleanup:
 
           if [[ "$pending_release" == "$RELEASE_NAME" ]]; then
             secret_to_delete=$(kubectl get secret -l owner=helm,status=pending-upgrade,name="$RELEASE_NAME" -n "$NAMESPACE" | awk '{print $1}' | grep -v NAME)
-            kubectl describe secret -n "$NAMESPACE" "$secret_to_delete"
+            kubectl delete secret -n "$NAMESPACE" "$secret_to_delete"
           fi
 
 helm-release-information:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -240,7 +240,7 @@ helm-cleanup:
             done
           fi
 
-          #Workaround for previous release stuck in pending state
+          # Workaround for previous Helm release stuck in pending state
           pending_release=$(helm list -n "$NAMESPACE" --pending --filter="(\s|^)($RELEASE_NAME)(\s|$)"| tail -1 | cut -f1)
 
           if [[ "$pending_release" == "$RELEASE_NAME" ]]; then


### PR DESCRIPTION
Workaround for the issue in https://github.com/helm/helm/issues/4558

Deletes the latest secret of stuck pending-upgrade Helm release.