### PR TITLE
Use more recent docker version to fix Alpine 3.14+ builds

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -113,8 +113,10 @@ silta-setup:
       default: ''
   steps:
     - setup_remote_docker:
-        # Note: default Docker version is 17.09. Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
-        version: 19.03.8
+        # Note: default Docker version is 17.09.
+        # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
+        # Alpine 3.14+ builds require 20.10.0+
+        version: 20.10.7
     - set-up-socks-proxy
     - cloud-login
     - docker-login


### PR DESCRIPTION
Docker engine upgrade
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2