### PR TITLE
Iterate comma separated secret filenames

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -339,7 +339,9 @@ decrypt-files:
           secrets='<<parameters.files>>'
           if [[ ! -z "$secrets" ]]; then
             echo "Decrypting secrets"
-            for file in ${secrets//,/}
+            # Replace comma with whitespace and iterate all whitespace separated values.
+            # This also means there can't be commas and whitespaces in filenames.
+            for file in ${secrets//,/" "}
             do
               echo "$file"
               tmp=$(mktemp)


### PR DESCRIPTION
Replaces comma with whitespace and iterate all whitespace separated values.

It allowed space separated values before the change, i.e. `secret1 secret2`, now also allows comma separated values like `secret1,secret2` and even mixed formatting - 
```
decrypt-files:
  files: secret1 secret2,secret3, secret4
```

Build log:
```
secret1
renamed '/tmp/tmp.iRPAbj157Q' -> 'secret1'
secret2
renamed '/tmp/tmp.OPCim2aOiA' -> 'secret2'
secret3
renamed '/tmp/tmp.7wuKdr5Ag9' -> 'secret3'
secret4
renamed '/tmp/tmp.97AeQ18Zus' -> 'secret4'
```