### PR TITLE
Define npm_config_platform=linuxmusl for npm install.

### DIFF
--- a/orb/commands/@npm.yml
+++ b/orb/commands/@npm.yml
@@ -24,6 +24,8 @@ npm-install-build:
 
     - run:
         name: Install frontend dependencies
+        environment:
+          npm_config_platform: linuxmusl
         command: |
           cd '<<parameters.path>>'
           <<parameters.install-command>>


### PR DESCRIPTION
We use Alpine based images for run containers, but the build container is Debian based resulting in binary libraries being installed with wrong standards library version.
For npm it is possible to define the desired platform so correct versions are installed using the `npm_config_platform` environment variable.