### PR TITLE
Dev

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -73,25 +73,19 @@ silta-cli-setup:
           mkdir -p ~/.local/bin
 
           # Latest tagged release
-          #echo "test1"
-          # latest_release_url=$(curl -sL https://api.github.com/repos/wunderio/silta-cli/releases/latest | grep -o -E "https://(.*)silta-(.*)-linux-amd64.tar.gz" | head -1)
-          
-          #echo "test2"
-          #curl -sL $latest_release_url | tar xz -C ~/.local/bin
+          latest_release_url=$(curl -s https://api.github.com/repos/wunderio/silta-cli/releases/latest | jq -r '.assets[] | .browser_download_url | select(endswith("linux-amd64.tar.gz"))')
+          curl -sL $latest_release_url | tar xz -C ~/.local/bin
 
           # Selected release, i.e. 1.0.1
           # curl -sL https://github.com/wunderio/silta-cli/releases/download/0.1.0/silta-0.1.0-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
           # Latest build from master branch
-          curl -sL https://github.com/wunderio/silta-cli/releases/download/master/silta-master-linux-amd64.tar.gz | tar xz -C ~/.local/bin
+          # curl -sL https://github.com/wunderio/silta-cli/releases/download/master/silta-master-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
           # Latest build from test release
           # curl -sL https://github.com/wunderio/silta-cli/releases/download/test/silta-test-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
-          echo "test3"
           silta version
-
-          echo "test4"
 
 docker-login:
   description: "Login to the docker registry."

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -73,19 +73,25 @@ silta-cli-setup:
           mkdir -p ~/.local/bin
 
           # Latest tagged release
-          latest_release_url=$(curl -sL https://api.github.com/repos/wunderio/silta-cli/releases/latest | grep -o -E "https://(.*)silta-(.*)-linux-amd64.tar.gz" | head -1)
-          curl -sL $latest_release_url | tar xz -C ~/.local/bin
+          #echo "test1"
+          # latest_release_url=$(curl -sL https://api.github.com/repos/wunderio/silta-cli/releases/latest | grep -o -E "https://(.*)silta-(.*)-linux-amd64.tar.gz" | head -1)
+          
+          #echo "test2"
+          #curl -sL $latest_release_url | tar xz -C ~/.local/bin
 
           # Selected release, i.e. 1.0.1
           # curl -sL https://github.com/wunderio/silta-cli/releases/download/0.1.0/silta-0.1.0-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
           # Latest build from master branch
-          # curl -sL https://github.com/wunderio/silta-cli/releases/download/master/silta-master-linux-amd64.tar.gz | tar xz -C ~/.local/bin
+          curl -sL https://github.com/wunderio/silta-cli/releases/download/master/silta-master-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
           # Latest build from test release
           # curl -sL https://github.com/wunderio/silta-cli/releases/download/test/silta-test-linux-amd64.tar.gz | tar xz -C ~/.local/bin
 
+          echo "test3"
           silta version
+
+          echo "test4"
 
 docker-login:
   description: "Login to the docker registry."


### PR DESCRIPTION
Use jq to select archive from latest releases list. `head -n 1` breaks pipe with error 141 on alpine, might as well trap it, but this one works too.