### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -5,7 +5,7 @@ description: "A collection of CircleCI tools used by the Silta hosting infrastru
 executors:
   silta:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
+      - image: wunderio/silta-cicd:circleci-php7.3-node12-composer1-v0.1
   sonar:
     docker:
       - image: wunderio/circleci-sonar-scanner:latest


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.