### PR TITLE
Do not convert CIRCLE_BRANCH to lower case

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -33,7 +33,7 @@ build-docker-image:
         command: |
 
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
-          BRANCHNAME="${CIRCLE_BRANCH,,}"
+          BRANCHNAME="${CIRCLE_BRANCH}"
 
           IMAGE_URL=$(silta ci image url \
             --image-repo-host "${DOCKER_REPO_HOST}" \
@@ -127,7 +127,7 @@ set-release-name:
         command: |
           
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
-          BRANCHNAME="${CIRCLE_BRANCH,,}"
+          BRANCHNAME="${CIRCLE_BRANCH}"
           
           RELEASE_NAME=$(silta ci release name --branchname "${BRANCHNAME}" --release-suffix "<<parameters.release-suffix>>")
           SILTA_ENVIRONMENT_NAME=$(silta ci release environmentname --branchname "${BRANCHNAME}" --release-suffix "<<parameters.release-suffix>>")

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -138,7 +138,7 @@ drupal-helm-deploy:
         no_output_timeout: '<<parameters.deployment_timeout>>'
         command: |
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
-          BRANCHNAME="${CIRCLE_BRANCH,,}"
+          BRANCHNAME="${CIRCLE_BRANCH}"
           REPOSITORY_URL="${CIRCLE_REPOSITORY_URL}"
 
           PHP_IMAGE_URL=${php_IMAGE_URL}

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -81,7 +81,7 @@ frontend-build-deploy:
               name: Deploy helm release
               command: |
                 NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
-                BRANCHNAME="${CIRCLE_BRANCH,,}"
+                BRANCHNAME="${CIRCLE_BRANCH}"
                 REPOSITORY_URL="${CIRCLE_REPOSITORY_URL}"
                 
                 image_overrides=""

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -98,7 +98,7 @@ simple-build-deploy:
               name: Deploy helm release
               command: |
                 NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
-                BRANCHNAME="${CIRCLE_BRANCH,,}"
+                BRANCHNAME="${CIRCLE_BRANCH}"
                 
                 NGINX_IMAGE_URL=${nginx_IMAGE_URL}
                 


### PR DESCRIPTION
CI should not convert CIRCLE_BRANCH to lower case for branchname variable as it messes up deployment removal.