### PR TITLE
Request kubernetes connection credentials from Silta Dashboard

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -138,11 +138,15 @@ set-release-name:
 
           echo "The release name for this branch is \"$RELEASE_NAME\" in the \"$NAMESPACE\" namespace"
 
-# This will be deprecated in favor of cloud-login job
+# TODO: Remove this if You see it after 2023.06.01
 gcloud-login:
   description: "Deprecated. Replace this with cloud-login job!"
   steps:
-    - cloud-login
+    - run:
+        name: "Deprecated. Replace this with cloud-login job!"
+        command: |
+          echo "Deprecated. Replace this with cloud-login job!"
+          exit 1
 
 cloud-login:
   description: "Cloud login."
@@ -150,7 +154,36 @@ cloud-login:
     - run:
         name: Cloud login
         command: |
-          silta cloud login --cluster-name "${CLUSTER_NAME}"
+          # Try to find the shared service account key first
+          # if KUBECTL_CONFIG environment variable is set then connect
+          # to the cluster using that kubeconfig
+          if [ ! -z "${KUBECTL_CONFIG}" ]; then
+            silta cloud login --cluster-name "${CLUSTER_NAME}"
+          fi
+
+          # Alternatively, check if ${SILTA_CLUSTER_ID}_KUBECTL_CONFIG is set.
+          KUBECTL_CONFIG_VAR="${SILTA_CLUSTER_ID}_KUBECTL_CONFIG"
+          if [ ! -z "${!KUBECTL_CONFIG_VAR}" ]; then
+            export KUBECTL_CONFIG="${!KUBECTL_CONFIG_VAR}"
+            echo "export KUBECTL_CONFIG=${!KUBECTL_CONFIG_VAR}" >> $BASH_ENV
+            silta cloud login --cluster-name "${CLUSTER_NAME}"
+            
+          else
+            echo "Cluster connection credentials (${SILTA_CLUSTER_ID}_KUBECTL_CONFIG) are not set."
+
+            if [ ! -z "${SILTA_DASHBOARD_URL}" ]; then
+              echo "Attempting to request cluster connection credentials from the Silta Dashboard API."
+              NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
+              # Request kubeconfig injection from the Silta Dashboard API via curl request.
+              curl -X POST ${SILTA_DASHBOARD_URL}/api/circleci/reload-ns-rbac \
+                -H "Content-type: application/x-www-form-urlencoded" \
+                -d "rbac_reload_key=${SILTA_DASHBOARD_KEY}" \
+                -d "cluster=${SILTA_CLUSTER_ID}" \
+                -d "namespace=${NAMESPACE}" \
+              echo "Credentials requested, please rerun the build."
+            fi
+            exit 1
+          fi
 
 helm-cleanup:
   description: "Clean up failed Helm releases."


### PR DESCRIPTION
- Allow credential creation via dashboard callback
- gcloud-login deprecation (it has displayed deprecation message [for two years already](https://github.com/wunderio/silta-circleci/pull/147)) 

This still uses shared credentials by default and only uses override when they ain't present.