### PR TITLE
SLT-266: Asynchronous container image build

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -54,15 +54,13 @@ build-docker-image:
             --dockerfile "<<parameters.dockerfile>>" \
             --image-tag "<<parameters.tag>>" \
             --branchname "${BRANCHNAME}" \
-            --image-reuse <<parameters.reuse_image>> \
-            & 
+            --image-reuse <<parameters.reuse_image>>
 
           if [ '<<parameters.expose_image>>' = 'true' ]; then
             # Persist the image identifier and tag so it is available during deployment.
             echo "export <<parameters.identifier>>_IMAGE_IDENTIFIER='<<parameters.identifier>>'" >> "$BASH_ENV"
             echo "export <<parameters.identifier>>_IMAGE_URL='${IMAGE_URL}'" >> "$BASH_ENV"
           fi
-        background: true
 
 silta-cli-setup:
   description: "Download Silta CI tooling."
@@ -110,7 +108,6 @@ silta-setup:
         # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
         # Alpine 3.14+ builds require 20.10.0+
         version: 20.10.7
-        docker_layer_caching: true
     - set-up-socks-proxy
     - cloud-login
     - docker-login

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -108,6 +108,7 @@ silta-setup:
         # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
         # Alpine 3.14+ builds require 20.10.0+
         version: 20.10.7
+        docker_layer_caching: true
     - set-up-socks-proxy
     - cloud-login
     - docker-login

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -54,13 +54,15 @@ build-docker-image:
             --dockerfile "<<parameters.dockerfile>>" \
             --image-tag "<<parameters.tag>>" \
             --branchname "${BRANCHNAME}" \
-            --image-reuse <<parameters.reuse_image>>
+            --image-reuse <<parameters.reuse_image>> \
+            & 
 
           if [ '<<parameters.expose_image>>' = 'true' ]; then
             # Persist the image identifier and tag so it is available during deployment.
             echo "export <<parameters.identifier>>_IMAGE_IDENTIFIER='<<parameters.identifier>>'" >> "$BASH_ENV"
             echo "export <<parameters.identifier>>_IMAGE_URL='${IMAGE_URL}'" >> "$BASH_ENV"
           fi
+        background: true
 
 silta-cli-setup:
   description: "Download Silta CI tooling."

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -54,7 +54,8 @@ build-docker-image:
             --dockerfile "<<parameters.dockerfile>>" \
             --image-tag "<<parameters.tag>>" \
             --branchname "${BRANCHNAME}" \
-            --image-reuse <<parameters.reuse_image>>
+            --image-reuse <<parameters.reuse_image>> \
+            &
 
           if [ '<<parameters.expose_image>>' = 'true' ]; then
             # Persist the image identifier and tag so it is available during deployment.

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -29,7 +29,7 @@ build-docker-image:
       default: true
   steps:
     - run:
-        name: Build <<parameters.identifier>> docker image
+        name: Create <<parameters.identifier>> docker image url
         command: |
 
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
@@ -45,6 +45,20 @@ build-docker-image:
             --image-tag "<<parameters.tag>>"
           )
 
+          if [ '<<parameters.expose_image>>' = 'true' ]; then
+            # Persist the image identifier and tag so it is available during deployment.
+            echo "export <<parameters.identifier>>_IMAGE_IDENTIFIER='<<parameters.identifier>>'" >> "$BASH_ENV"
+            echo "export <<parameters.identifier>>_IMAGE_URL='${IMAGE_URL}'" >> "$BASH_ENV"
+          fi
+
+    - run:
+        name: Build <<parameters.identifier>> docker image
+        background: true
+        command: |
+
+          NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
+          BRANCHNAME="${CIRCLE_BRANCH}"
+
           silta ci image build \
             --image-repo-host "${DOCKER_REPO_HOST}" \
             --image-repo-project "${DOCKER_REPO_PROJ}" \
@@ -54,14 +68,7 @@ build-docker-image:
             --dockerfile "<<parameters.dockerfile>>" \
             --image-tag "<<parameters.tag>>" \
             --branchname "${BRANCHNAME}" \
-            --image-reuse <<parameters.reuse_image>> \
-            &
-
-          if [ '<<parameters.expose_image>>' = 'true' ]; then
-            # Persist the image identifier and tag so it is available during deployment.
-            echo "export <<parameters.identifier>>_IMAGE_IDENTIFIER='<<parameters.identifier>>'" >> "$BASH_ENV"
-            echo "export <<parameters.identifier>>_IMAGE_URL='${IMAGE_URL}'" >> "$BASH_ENV"
-          fi
+            --image-reuse <<parameters.reuse_image>>
 
 silta-cli-setup:
   description: "Download Silta CI tooling."

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -27,6 +27,10 @@ build-docker-image:
       description: "Use existing image if identical image:tag exists in remote"
       type: boolean
       default: true
+    background: 
+      description: "Run the image build process in the background."
+      type: boolean
+      default: false
   steps:
     - run:
         name: Create <<parameters.identifier>> docker image url
@@ -53,7 +57,7 @@ build-docker-image:
 
     - run:
         name: Build <<parameters.identifier>> docker image
-        background: true
+        background: <<parameters.background>>
         command: |
 
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -75,31 +75,47 @@ drupal-docker-build:
       type: string
       default: "web"
       description: "Path to be used as build context for Nginx image."
+    background:
+      type: boolean
+      default: true
+      description: "Run docker build in background."
+    wait:
+      type: boolean
+      default: true
+      description: "Wait for docker build to finish."
   steps:
     - build-docker-image:
         dockerfile: silta/nginx.Dockerfile
         path: <<parameters.nginx_build_context>>
         identifier: nginx
         docker-hash-prefix: v5
+        background: <<parameters.background>>
 
     - build-docker-image:
         dockerfile: silta/php.Dockerfile
         path: "."
         identifier: php
         docker-hash-prefix: v5
+        background: <<parameters.background>>
 
     - build-docker-image:
         dockerfile: silta/shell.Dockerfile
         path: "."
         identifier: shell
         docker-hash-prefix: v6
+        background: <<parameters.background>>
 
     - run:
-        name: Image build
+        name: Wait for docker images to be built
         command: |
-          echo "Waiting for docker images to be built."
-          ps -Alf
-          wait
+          if [ << parameters.wait >> = true ]; then
+              while true; do
+              if [ $(ps -ef | grep -v grep | grep "silta ci image build" | wc -l) -lt 1 ]; then
+                break
+              fi
+              sleep 1
+            done
+          fi
 
 drupal-helm-deploy:
   description: "Deploy helm release."

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -94,6 +94,13 @@ drupal-docker-build:
         identifier: shell
         docker-hash-prefix: v6
 
+    - run:
+        name: Image build
+        command: |
+          echo "Waiting for docker images to be built."
+          ps -Alf
+          wait
+
 drupal-helm-deploy:
   description: "Deploy helm release."
   parameters:

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -109,7 +109,7 @@ drupal-docker-build:
         name: Wait for docker images to be built
         command: |
           if [ << parameters.wait >> = true ]; then
-              while true; do
+            while true; do
               if [ $(ps -ef | grep -v grep | grep "silta ci image build" | wc -l) -lt 1 ]; then
                 break
               fi

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -94,12 +94,6 @@ drupal-docker-build:
         identifier: shell
         docker-hash-prefix: v6
 
-    - run:
-        name: Image build
-        command: |
-          echo "Waiting for docker images to be built."
-          wait < <(jobs -p)
-
 drupal-helm-deploy:
   description: "Deploy helm release."
   parameters:

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -94,6 +94,12 @@ drupal-docker-build:
         identifier: shell
         docker-hash-prefix: v6
 
+    - run:
+        name: Image build
+        command: |
+          echo "Waiting for docker images to be built."
+          wait < <(jobs -p)
+
 drupal-helm-deploy:
   description: "Deploy helm release."
   parameters:

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -139,6 +139,14 @@ drupal-build-deploy:
       description: "Path to be used as build context for Nginx image build."
       type: string
       default: "web"
+    image_build_background:
+      type: boolean
+      default: true
+      description: "Run docker build in background."
+    image_build_wait:
+      type: boolean
+      default: true
+      description: "Wait for docker build to finish."
     source_chart:
       description: "Chart to extend"
       type: string
@@ -174,6 +182,8 @@ drupal-build-deploy:
               silta_config: <<parameters.silta_config>>
           - drupal-docker-build:
               nginx_build_context: <<parameters.nginx_build_context>>
+              background: <<parameters.image_build_background>>
+              wait: <<parameters.image_build_wait>>
           - steps: <<parameters.pre-release>>
           - drupal-helm-deploy:
               chart_name: <<parameters.chart_name>>


### PR DESCRIPTION
This change allows non-blocking image build jobs that allow progressing with build process while images are being created. 

build-docker-image command accepts `background` parameter (false by default) that runs build step into [background](https://circleci.com/docs/configuration-reference/#background-commands). `drupal-docker-build` command has 2 new parameters now - `background` (default: true), that is passed to `build-docker-image` and `wait` (default: true) that will add extra step to build process, waiting for execution of those three images (nginx, php and shell). 

This parameter is accessible in parent command, `drupal-build-deploy` as `image_build_background` (default: true) and `image_build_wait` (default: true) . 

Only drupal chart builds will thread docker image build process. It will be enabled by default which will make builds faster, but there's an option to speed up build process even more, by setting `image_build_wait` to false. This will not block build process while images are building, but rather run up to release deployment step. If the images are still being built, containers won't start until images are ready and pushed to remote. 

Testing:
- Use `imgcache` dev orb in `.circleci/config.yml`:
```
orbs:
  silta: silta/silta@dev:imgcache
```
- Adjust `image_build_background` and `image_build_wait` parameters of `silta/drupal-build-deploy` job.