### PR TITLE
SLT-825: Provide a way to use Drupal dev charts

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -217,3 +217,18 @@ drupal-values-validate:
           --vpn-ip "${VPN_IP}" \
           --vpc-native "${VPC_NATIVE}" \
           --cluster-type "${CLUSTER_TYPE}"
+
+drupal-download-dev-chart:
+  steps:
+    - run:
+        name: Download charts from github repository
+        command: |
+          rm -rf ./charts
+          git clone --branch develop git@github.com:wunderio/charts.git
+    - run:
+        name: Add helm repositories and build local chart
+        command: |
+          helm repo add elastic https://helm.elastic.co
+          helm repo add codecentric https://codecentric.github.io/helm-charts
+          helm repo add percona https://percona.github.io/percona-helm-charts/
+          helm dependency build ./charts/drupal

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -79,7 +79,7 @@ drupal-validate:
 
     - steps: <<parameters.post-validation>>
 
-drupal-build-deploy:
+drupal-build-deploy: &drupal-build-deploy
   description: "Build and deploy drupal chart release."
   executor: <<parameters.executor>>
   parameters:
@@ -182,3 +182,21 @@ drupal-build-deploy:
               silta_config: <<parameters.silta_config>>
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
+
+drupal-build-deploy-dev-charts:
+  <<: *drupal-build-deploy
+  chart_name: "./charts/drupal"
+  chart_repository: ""
+  codebase-build:
+    - run:
+        name: Download charts from github repository
+        command: |
+          rm -rf ./charts
+          git clone --branch develop git@github.com:wunderio/charts.git
+    - run:
+        name: Add helm repositories and build local chart
+        command: |
+          helm repo add elastic https://helm.elastic.co
+          helm repo add codecentric https://codecentric.github.io/helm-charts
+          helm repo add percona https://percona.github.io/percona-helm-charts/
+          helm dependency build ./charts/drupal

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -185,18 +185,22 @@ drupal-build-deploy: &drupal-build-deploy
 
 drupal-build-deploy-dev-charts:
   <<: *drupal-build-deploy
-  chart_name: "./charts/drupal"
-  chart_repository: ""
-  codebase-build:
-    - run:
-        name: Download charts from github repository
-        command: |
-          rm -rf ./charts
-          git clone --branch develop git@github.com:wunderio/charts.git
-    - run:
-        name: Add helm repositories and build local chart
-        command: |
-          helm repo add elastic https://helm.elastic.co
-          helm repo add codecentric https://codecentric.github.io/helm-charts
-          helm repo add percona https://percona.github.io/percona-helm-charts/
-          helm dependency build ./charts/drupal
+  parameters:
+    codebase-build:
+      default:
+        - run:
+            name: Download charts from github repository
+            command: |
+              rm -rf ./charts
+              git clone --branch develop git@github.com:wunderio/charts.git
+        - run:
+            name: Add helm repositories and build local chart
+            command: |
+              helm repo add elastic https://helm.elastic.co
+              helm repo add codecentric https://codecentric.github.io/helm-charts
+              helm repo add percona https://percona.github.io/percona-helm-charts/
+              helm dependency build ./charts/drupal
+    chart_name:
+      default: "./charts/drupal"
+    chart_repository:
+      default: ""

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -185,22 +185,3 @@ drupal-build-deploy: &drupal-build-deploy
 
 drupal-build-deploy-dev-charts:
   <<: *drupal-build-deploy
-  parameters:
-    codebase-build:
-      default:
-        - run:
-            name: Download charts from github repository
-            command: |
-              rm -rf ./charts
-              git clone --branch develop git@github.com:wunderio/charts.git
-        - run:
-            name: Add helm repositories and build local chart
-            command: |
-              helm repo add elastic https://helm.elastic.co
-              helm repo add codecentric https://codecentric.github.io/helm-charts
-              helm repo add percona https://percona.github.io/percona-helm-charts/
-              helm dependency build ./charts/drupal
-    chart_name:
-      default: "./charts/drupal"
-    chart_repository:
-      default: ""

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -185,3 +185,4 @@ drupal-build-deploy: &drupal-build-deploy
 
 drupal-build-deploy-dev-charts:
   <<: *drupal-build-deploy
+  description: "Build and deploy using development charts."

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -112,7 +112,7 @@ drupal-build-deploy: &drupal-build-deploy
       type: string
       default: https://storage.googleapis.com/charts.wdr.io
     use_dev_chart:
-      description: "Use development version of the Drupal chart."
+      description: "Internal use only. Used by drupal-build-deploy-dev-charts."
       type: boolean
       default: false
     decrypt_files:
@@ -164,8 +164,6 @@ drupal-build-deploy: &drupal-build-deploy
                 condition: <<parameters.use_dev_chart>>
                 steps:
                   - drupal-download-dev-chart
-                  - chart_name: "./charts/drupal"
-                  - chart_repository: ""
           - when:
               condition: <<parameters.decrypt_files>>
               steps:
@@ -193,6 +191,8 @@ drupal-build-deploy: &drupal-build-deploy
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
 
+# Job to build and deploy using development charts. This extends the
+# drupal-build-deploy job and overrides some of the parameters.
 drupal-build-deploy-dev-charts:
   <<: *drupal-build-deploy
   description: "Build and deploy using development charts."

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -111,6 +111,10 @@ drupal-build-deploy: &drupal-build-deploy
       description: "Helm chart repository."
       type: string
       default: https://storage.googleapis.com/charts.wdr.io
+    use_dev_chart:
+      descripition: "Use development version of the Drupal chart."
+      type: boolean
+      default: false
     decrypt_files:
       description: "Encrypted value files. Can have multiple, comma separated values."
       type: string
@@ -156,6 +160,13 @@ drupal-build-deploy: &drupal-build-deploy
     - unless:
         condition: <<parameters.skip-deployment>>
         steps:
+          - when:
+                condition: <<parameters.use_dev_chart>>
+                steps:
+                  - drupal-download-dev-chart
+                parameters:
+                  chart_name: "./charts/drupal"
+                  chart_repository: ""
           - when:
               condition: <<parameters.decrypt_files>>
               steps:

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -112,7 +112,7 @@ drupal-build-deploy: &drupal-build-deploy
       type: string
       default: https://storage.googleapis.com/charts.wdr.io
     use_dev_chart:
-      descripition: "Use development version of the Drupal chart."
+      description: "Use development version of the Drupal chart."
       type: boolean
       default: false
     decrypt_files:
@@ -199,6 +199,7 @@ drupal-build-deploy-dev-charts:
   description: "Build and deploy using development charts."
   parameters:
     <<: *drupal-build-deploy-params
+    # TODO: What if project job already overrides codebase-build step? Maybe create a completely new step instead, or a boolean value for "use dev charts".
     codebase-build:
       description: "Preparational build steps run after code checkout."
       type: steps

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -82,7 +82,7 @@ drupal-validate:
 drupal-build-deploy: &drupal-build-deploy
   description: "Build and deploy drupal chart release."
   executor: <<parameters.executor>>
-  parameters:
+  parameters: &drupal-build-deploy-params
     executor:
       description: "The name of custom executor to use."
       type: executor
@@ -187,14 +187,7 @@ drupal-build-deploy-dev-charts:
   <<: *drupal-build-deploy
   description: "Build and deploy using development charts."
   parameters:
-    executor:
-      description: "The name of custom executor to use."
-      type: executor
-      default: silta
-    drupal-root:
-      description: "Relative path to drupal root"
-      type: string
-      default: "."
+    <<: *drupal-build-deploy-params
     codebase-build:
       description: "Preparational build steps run after code checkout."
       type: steps
@@ -211,55 +204,11 @@ drupal-build-deploy-dev-charts:
               helm repo add codecentric https://codecentric.github.io/helm-charts
               helm repo add percona https://percona.github.io/percona-helm-charts/
               helm dependency build ./charts/drupal
-    pre-release:
-      description: "Steps to be executed before the Helm release is created."
-      type: steps
-      default: [ ]
     chart_name:
       description: "Helm chart name."
       type: string
       default: "./charts/drupal"
-    chart_version:
-      description: "Deploy specific drupal helm chart version."
-      type: string
-      default: ""
     chart_repository:
       description: "Helm chart repository."
       type: string
       default: ""
-    decrypt_files:
-      description: "Encrypted value files. Can have multiple, comma separated values."
-      type: string
-      default: ""
-    silta_config:
-      description: "Chart values override file. Can have multiple, comma separated values."
-      type: string
-      default: "silta/silta.yml"
-    skip-deployment:
-      description: "Skip release deployment."
-      type: boolean
-      default: false
-    cluster_domain:
-      description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
-      type: env_var_name
-      default: CLUSTER_DOMAIN
-    release-suffix:
-      description: "Release name suffix."
-      type: string
-      default: ''
-    deployment_timeout:
-      description: "Helm release deployment timeout."
-      type: string
-      default: "15m"
-    nginx_build_context:
-      description: "Path to be used as build context for Nginx image build."
-      type: string
-      default: "web"
-    source_chart:
-      description: "Chart to extend"
-      type: string
-      default: ''
-    extension_file:
-      description: "Extension config for the source chart"
-      type: string
-      default: ''

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -186,3 +186,80 @@ drupal-build-deploy: &drupal-build-deploy
 drupal-build-deploy-dev-charts:
   <<: *drupal-build-deploy
   description: "Build and deploy using development charts."
+  parameters:
+    executor:
+      description: "The name of custom executor to use."
+      type: executor
+      default: silta
+    drupal-root:
+      description: "Relative path to drupal root"
+      type: string
+      default: "."
+    codebase-build:
+      description: "Preparational build steps run after code checkout."
+      type: steps
+      default:
+        - run:
+            name: Download charts from github repository
+            command: |
+              rm -rf ./charts
+              git clone --branch develop git@github.com:wunderio/charts.git
+        - run:
+            name: Add helm repositories and build local chart
+            command: |
+              helm repo add elastic https://helm.elastic.co
+              helm repo add codecentric https://codecentric.github.io/helm-charts
+              helm repo add percona https://percona.github.io/percona-helm-charts/
+              helm dependency build ./charts/drupal
+    pre-release:
+      description: "Steps to be executed before the Helm release is created."
+      type: steps
+      default: [ ]
+    chart_name:
+      description: "Helm chart name."
+      type: string
+      default: "./charts/drupal"
+    chart_version:
+      description: "Deploy specific drupal helm chart version."
+      type: string
+      default: ""
+    chart_repository:
+      description: "Helm chart repository."
+      type: string
+      default: ""
+    decrypt_files:
+      description: "Encrypted value files. Can have multiple, comma separated values."
+      type: string
+      default: ""
+    silta_config:
+      description: "Chart values override file. Can have multiple, comma separated values."
+      type: string
+      default: "silta/silta.yml"
+    skip-deployment:
+      description: "Skip release deployment."
+      type: boolean
+      default: false
+    cluster_domain:
+      description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
+      type: env_var_name
+      default: CLUSTER_DOMAIN
+    release-suffix:
+      description: "Release name suffix."
+      type: string
+      default: ''
+    deployment_timeout:
+      description: "Helm release deployment timeout."
+      type: string
+      default: "15m"
+    nginx_build_context:
+      description: "Path to be used as build context for Nginx image build."
+      type: string
+      default: "web"
+    source_chart:
+      description: "Chart to extend"
+      type: string
+      default: ''
+    extension_file:
+      description: "Extension config for the source chart"
+      type: string
+      default: ''

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -164,9 +164,8 @@ drupal-build-deploy: &drupal-build-deploy
                 condition: <<parameters.use_dev_chart>>
                 steps:
                   - drupal-download-dev-chart
-                parameters:
-                  chart_name: "./charts/drupal"
-                  chart_repository: ""
+                  - chart_name: "./charts/drupal"
+                  - chart_repository: ""
           - when:
               condition: <<parameters.decrypt_files>>
               steps:
@@ -199,23 +198,10 @@ drupal-build-deploy-dev-charts:
   description: "Build and deploy using development charts."
   parameters:
     <<: *drupal-build-deploy-params
-    # TODO: What if project job already overrides codebase-build step? Maybe create a completely new step instead, or a boolean value for "use dev charts".
-    codebase-build:
-      description: "Preparational build steps run after code checkout."
-      type: steps
-      default:
-        - run:
-            name: Download charts from github repository
-            command: |
-              rm -rf ./charts
-              git clone --branch develop git@github.com:wunderio/charts.git
-        - run:
-            name: Add helm repositories and build local chart
-            command: |
-              helm repo add elastic https://helm.elastic.co
-              helm repo add codecentric https://codecentric.github.io/helm-charts
-              helm repo add percona https://percona.github.io/percona-helm-charts/
-              helm dependency build ./charts/drupal
+    use_dev_chart:
+      description: "Use development version of the Drupal chart."
+      type: boolean
+      default: true
     chart_name:
       description: "Helm chart name."
       type: string


### PR DESCRIPTION
Proposed changes:
- Create a new command called _drupal-download-dev-chart_
- Create a new job called _drupal-build-deploy-dev-charts_
- Update job _drupal-build-deploy_ to conditionally download dev charts