### PR TITLE
SLT-862 image prefix

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -46,7 +46,8 @@ build-docker-image:
             --image-identifier "<<parameters.identifier>>" \
             --build-path "<<parameters.path>>" \
             --dockerfile "<<parameters.dockerfile>>" \
-            --image-tag "<<parameters.docker-hash-prefix>>-<<parameters.tag>>"
+            --image-tag "<<parameters.tag>>" \
+            --image-tag-prefix "<<parameters.docker-hash-prefix>>" \
           )
 
           if [ '<<parameters.expose_image>>' = 'true' ]; then
@@ -70,7 +71,8 @@ build-docker-image:
             --image-identifier "<<parameters.identifier>>" \
             --build-path "<<parameters.path>>" \
             --dockerfile "<<parameters.dockerfile>>" \
-            --image-tag "<<parameters.docker-hash-prefix>>-<<parameters.tag>>" \
+            --image-tag-prefix "<<parameters.docker-hash-prefix>>" \
+            --image-tag "<<parameters.tag>>" \
             --branchname "${BRANCHNAME}" \
             --image-reuse <<parameters.reuse_image>>
 

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -12,7 +12,7 @@ build-docker-image:
       description: "Image identifier."
       type: string
     docker-hash-prefix:
-      description: "Image tag prefix. Allows overriding cached images. (DEPRECATED)"
+      description: "Image tag prefix. Allows overriding cached images."
       type: string
       default: v1
     tag:
@@ -46,7 +46,7 @@ build-docker-image:
             --image-identifier "<<parameters.identifier>>" \
             --build-path "<<parameters.path>>" \
             --dockerfile "<<parameters.dockerfile>>" \
-            --image-tag "<<parameters.tag>>"
+            --image-tag "<<parameters.docker-hash-prefix>>-<<parameters.tag>>"
           )
 
           if [ '<<parameters.expose_image>>' = 'true' ]; then
@@ -70,7 +70,7 @@ build-docker-image:
             --image-identifier "<<parameters.identifier>>" \
             --build-path "<<parameters.path>>" \
             --dockerfile "<<parameters.dockerfile>>" \
-            --image-tag "<<parameters.tag>>" \
+            --image-tag "<<parameters.docker-hash-prefix>>-<<parameters.tag>>" \
             --branchname "${BRANCHNAME}" \
             --image-reuse <<parameters.reuse_image>>
 

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -88,21 +88,21 @@ drupal-docker-build:
         dockerfile: silta/nginx.Dockerfile
         path: <<parameters.nginx_build_context>>
         identifier: nginx
-        docker-hash-prefix: v5
+        docker-hash-prefix: v1
         background: <<parameters.background>>
 
     - build-docker-image:
         dockerfile: silta/php.Dockerfile
         path: "."
         identifier: php
-        docker-hash-prefix: v5
+        docker-hash-prefix: v1
         background: <<parameters.background>>
 
     - build-docker-image:
         dockerfile: silta/shell.Dockerfile
         path: "."
         identifier: shell
-        docker-hash-prefix: v6
+        docker-hash-prefix: v1
         background: <<parameters.background>>
 
     - run:

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -42,7 +42,7 @@ frontend-build-deploy:
           dockerfile: 'silta/node.Dockerfile'
           path: '.'
           identifier: 'node'
-          docker-hash-prefix: v6
+          docker-hash-prefix: v1
     release-suffix:
       description: "Release name suffix."
       type: string

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -85,7 +85,7 @@ simple-build-deploy:
         dockerfile: 'silta/nginx.Dockerfile'
         path: <<parameters.build_folder>>
         identifier: 'nginx'
-        docker-hash-prefix: v7
+        docker-hash-prefix: v1
 
     - steps: <<parameters.pre-release>>
 


### PR DESCRIPTION
Add back image tag prefixes.
Reset the tag back to v1 as `v1-<project hash>` wont start with collisions of already tagged images.

This PR should merged only after the corresponding [Silta CLI PR](https://github.com/wunderio/silta-cli/pull/48) is released.