### PR TITLE
get build process list and get exit codes

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -64,6 +64,14 @@ build-docker-image:
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
           BRANCHNAME="${CIRCLE_BRANCH}"
 
+          # Create temporary file for storing build process exit code with "build_process" prefix.
+          exit_code_file=$(mktemp /tmp/build-docker-image.XXXXXX)          
+          touch $exit_code_file
+
+          # Trap and store exit code of the build process.
+          trap 'echo $? > $exit_code_file' EXIT
+
+          # Build the docker image.
           silta ci image build \
             --image-repo-host "${DOCKER_REPO_HOST}" \
             --image-repo-project "${DOCKER_REPO_PROJ}" \

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -109,12 +109,19 @@ drupal-docker-build:
         name: Wait for docker images to be built
         command: |
           if [ << parameters.wait >> = true ]; then
-            while true; do
-              if [ $(ps -ef | grep -v grep | grep "silta ci image build" | wc -l) -lt 1 ]; then
-                break
+
+            # List all files with /tmp/build-docker-image.XXXX prefix.
+            # Wait until files have content and then print the content (exit code).
+            # If file content is not empty, then docker build has not finished yet.
+            while read -r file; do
+              while [ ! -s "$file" ]; do
+                sleep 1
+              done
+              exit_code=$(cat "$file")
+              if [ $exit_code -ne 0 ]; then
+                exit $exit_code
               fi
-              sleep 1
-            done
+            done < <(find /tmp -maxdepth 1 -type f -name 'build-docker-image.*')
           fi
 
 drupal-helm-deploy:


### PR DESCRIPTION
This will monitor image build subprocesses and fail the build if image build returns non-zero exit code. Storing pid's in files is required because image build processes ain't child processes, they are in a different process thread.