### PR TITLE
SLT-892: Define default machine types

### DIFF
--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -30,8 +30,8 @@ drupal-validate:
       default: silta
     resource_class:
       description: "The name of resource class to use."
-      type: resource_class
-      default: string
+      type: string
+      default: small
     drupal-root:
       description: "Relative path to drupal root"
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -92,11 +92,17 @@ drupal-validate:
 drupal-build-deploy: &drupal-build-deploy
   description: "Build and deploy drupal chart release."
   executor: <<parameters.executor>>
+  resource_class: <<parameters.resource_class>>
   parameters: &drupal-build-deploy-params
     executor:
       description: "The name of custom executor to use."
       type: executor
       default: silta
+    resource_class:
+      description: "The name of resource class to use."
+      type: string
+      # This job uses Remote Docker Executor, for which medium is the smallest available resource class.
+      default: medium
     drupal-root:
       description: "Relative path to drupal root"
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -31,7 +31,7 @@ drupal-validate:
     resource_class:
       description: "The name of resource class to use."
       type: resource_class
-      default: small
+      default: string
     drupal-root:
       description: "Relative path to drupal root"
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -1,12 +1,16 @@
 analyze:
   description: "Drupal code analyze job."
   executor: <<parameters.executor>>
-  resource_class: small
+  resource_class: <<parameters.resource_class>>
   parameters:
     executor:
       description: "The name of custom executor to use."
       type: executor
       default: sonar
+    resource_class:
+      description: "The name of resource class to use."
+      type: string
+      default: small
     sources:
       description: "Codebase scan paths."
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -1,6 +1,7 @@
 analyze:
   description: "Drupal code analyze job."
   executor: <<parameters.executor>>
+  resource_class: small
   parameters:
     executor:
       description: "The name of custom executor to use."
@@ -21,6 +22,7 @@ analyze:
 drupal-validate:
   description: "Drupal code validation job."
   executor: <<parameters.executor>>
+  resource_class: small
   parameters:
     executor:
       description: "The name of custom executor to use."

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -22,12 +22,16 @@ analyze:
 drupal-validate:
   description: "Drupal code validation job."
   executor: <<parameters.executor>>
-  resource_class: small
+  resource_class: <<parameters.resource_class>>
   parameters:
     executor:
       description: "The name of custom executor to use."
       type: executor
       default: silta
+    resource_class:
+      description: "The name of resource class to use."
+      type: resource_class
+      default: small
     drupal-root:
       description: "Relative path to drupal root"
       type: string

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -1,11 +1,17 @@
 frontend-build-deploy:
   description: "Build and deploy frontend chart release."
   executor: <<parameters.executor>>
+  resource_class: <<parameters.resource_class>>
   parameters:
     executor:
       description: "The name of custom executor to use."
       type: executor
       default: silta
+    resource_class:
+      description: "The name of resource class to use."
+      type: string
+      # This job uses Remote Docker Executor, for which medium is the smallest available resource class.
+      default: medium
     codebase-build:
       description: "Preparational build steps run after code checkout."
       type: steps
@@ -68,7 +74,7 @@ frontend-build-deploy:
         source_chart: '<<parameters.source_chart>>'
         extension_file: '<<parameters.extension_file>>'
         chart_version: '<<parameters.chart_version>>'
-        
+
     - steps: <<parameters.image_build_steps>>
 
     - unless:

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -7,6 +7,11 @@ simple-build-deploy:
       description: "The name of custom executor to use."
       type: executor
       default: silta
+    resource_class:
+      description: "The name of resource class to use."
+      type: string
+      # This job uses Remote Docker Executor, for which medium is the smallest available resource class.
+      default: medium
     codebase-build:
       description: "Preparational build steps run after code checkout."
       type: steps
@@ -51,11 +56,6 @@ simple-build-deploy:
       description: "Release name suffix."
       type: string
       default: ''
-    resource_class:
-      description: "Amount of CPU and RAM allocated to each CircleCI executor container in a build job. See [CircleCI reference](https://circleci.com/docs/2.0/configuration-reference/#resourceclass)."
-      type: string
-      # Medium is the default when not specified.
-      default: medium
     source_chart:
       description: "Chart to extend"
       type: string


### PR DESCRIPTION
Adds default resource_class definitions, which previously did not exist. Make resource_class a parameter so that it can be overridden.

Sets the default to the smallest available resource class for each job.

Tested with drupal-project-k8s, here is an example deployment that uses this development orb: https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s/5719/workflows/2c7ec76c-f59f-4733-a73b-e6d4c2426edf. When clicking into the different jobs, you can see which Executor and Resource class was used.