### PR TITLE
SLT-913: Split drupal-build-deploy into two separate jobs

### DIFF
--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -6,7 +6,6 @@ executors:
   silta:
     docker:
       - image: wunderio/silta-cicd:circleci-php7.3-node12-composer1-v1
-    resource_class: small
   sonar:
     docker:
       - image: wunderio/circleci-sonar-scanner:latest

--- a/orb/@orb.yml
+++ b/orb/@orb.yml
@@ -6,6 +6,7 @@ executors:
   silta:
     docker:
       - image: wunderio/silta-cicd:circleci-php7.3-node12-composer1-v0.1
+    resource_class: small
   sonar:
     docker:
       - image: wunderio/circleci-sonar-scanner:latest

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -95,6 +95,15 @@ docker-login:
         command: |
           silta ci image login
 
+docker-setup:
+  description: "Set up Docker."
+  steps:
+    - setup_remote_docker:
+        # Note: default Docker version is 17.09.
+        # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
+        # Alpine 3.14+ builds require 20.10.0+
+        version: 20.10.7
+
 silta-setup:
   description: "Set up silta cluster connection and set release name."
   parameters:
@@ -103,11 +112,6 @@ silta-setup:
       type: string
       default: ''
   steps:
-    - setup_remote_docker:
-        # Note: default Docker version is 17.09.
-        # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
-        # Alpine 3.14+ builds require 20.10.0+
-        version: 20.10.7
     - set-up-socks-proxy
     - cloud-login
     - docker-login

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -103,11 +103,11 @@ silta-setup:
       type: string
       default: ''
   steps:
-    #- setup_remote_docker:
+    - setup_remote_docker:
         # Note: default Docker version is 17.09.
         # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
         # Alpine 3.14+ builds require 20.10.0+
-    #    version: 20.10.7
+        version: 20.10.7
     - set-up-socks-proxy
     - cloud-login
     - docker-login

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -103,11 +103,11 @@ silta-setup:
       type: string
       default: ''
   steps:
-    - setup_remote_docker:
+    #- setup_remote_docker:
         # Note: default Docker version is 17.09.
         # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
         # Alpine 3.14+ builds require 20.10.0+
-        version: 20.10.7
+    #    version: 20.10.7
     - set-up-socks-proxy
     - cloud-login
     - docker-login
@@ -235,7 +235,7 @@ set-up-socks-proxy:
         command: |
           if [[ -n "$TUNNEL_PRIVATE_KEY" ]]; then
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
-          fi    
+          fi
     - run:
         name: Open up a tunnel
         command: |

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -27,7 +27,7 @@ build-docker-image:
       description: "Use existing image if identical image:tag exists in remote"
       type: boolean
       default: true
-    background: 
+    background:
       description: "Run the image build process in the background."
       type: boolean
       default: false
@@ -120,11 +120,7 @@ docker-login:
 docker-setup:
   description: "Set up Docker."
   steps:
-    - setup_remote_docker:
-        # Note: default Docker version is 17.09.
-        # Using BuildKit requires version 18.09 and dockerignore per dockerfile from 19.03
-        # Alpine 3.14+ builds require 20.10.0+
-        version: 20.10.7
+    - setup_remote_docker
 
 silta-setup:
   description: "Set up silta cluster connection and set release name."

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -251,7 +251,7 @@ drupal-values-validate:
 drupal-download-dev-chart:
   steps:
     - run:
-        name: Download charts from github repository
+        name: Download development charts from github repository
         command: |
           rm -rf ./charts
           git clone --branch develop git@github.com:wunderio/charts.git

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -329,7 +329,7 @@ drupal-deploy:
     chart_version:
       description: "Deploy specific drupal helm chart version."
       type: string
-      default: ""
+      default: "^1.x"
     chart_repository:
       description: "Helm chart repository."
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -226,11 +226,17 @@ drupal-build-deploy-dev-charts:
 drupal-build:
   description: "Build Drupal chart release."
   executor: <<parameters.executor>>
+  resource_class: <<parameters.resource_class>>
   parameters:
     executor:
       description: "The name of custom executor to use."
       type: executor
       default: silta
+    resource_class:
+      description: "The name of resource class to use."
+      type: string
+      # This job uses Remote Docker Executor, for which medium is the smallest available resource class.
+      default: medium
     drupal-root:
       description: "Relative path to drupal root"
       type: string
@@ -288,12 +294,16 @@ drupal-build:
 drupal-deploy:
   description: "Deploy drupal chart release."
   executor: <<parameters.executor>>
-  resource_class: small
+  resource_class: <<parameters.resource_class>>
   parameters:
     executor:
       description: "The name of custom executor to use."
       type: executor
       default: silta
+    resource_class:
+      description: "The name of resource class to use."
+      type: string
+      default: small
     drupal-root:
       description: "Relative path to drupal root"
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -1,6 +1,7 @@
 analyze:
   description: "Drupal code analyze job."
   executor: <<parameters.executor>>
+  resource_class: small
   parameters:
     executor:
       description: "The name of custom executor to use."
@@ -21,6 +22,7 @@ analyze:
 drupal-validate:
   description: "Drupal code validation job."
   executor: <<parameters.executor>>
+  resource_class: small
   parameters:
     executor:
       description: "The name of custom executor to use."
@@ -220,3 +222,212 @@ drupal-build-deploy-dev-charts:
       description: "Helm chart repository."
       type: string
       default: ""
+
+  drupal-build:
+    description: "Build Drupal chart release."
+    executor: <<parameters.executor>>
+    parameters:
+      executor:
+        description: "The name of custom executor to use."
+        type: executor
+        default: silta
+      drupal-root:
+        description: "Relative path to drupal root"
+        type: string
+        default: "."
+      codebase-build:
+        description: "Preparational build steps run after code checkout."
+        type: steps
+        default: []
+      pre-release:
+        description: "Steps to be executed before the Helm release is created."
+        type: steps
+        default: []
+      chart_name:
+        description: "Helm chart name."
+        type: string
+        default: drupal
+      chart_version:
+        description: "Deploy specific drupal helm chart version."
+        type: string
+        default: ""
+      chart_repository:
+        description: "Helm chart repository."
+        type: string
+        default: https://storage.googleapis.com/charts.wdr.io
+      decrypt_files:
+        description: "Encrypted value files. Can have multiple, comma separated values."
+        type: string
+        default: ""
+      silta_config:
+        description: "Chart values override file. Can have multiple, comma separated values."
+        type: string
+        default: "silta/silta.yml"
+      skip-deployment:
+        description: "Skip release deployment."
+        type: boolean
+        default: false
+      cluster_domain:
+        description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
+        type: env_var_name
+        default: CLUSTER_DOMAIN
+      release-suffix:
+        description: "Release name suffix."
+        type: string
+        default: ''
+      deployment_timeout:
+        description: "Helm release deployment timeout."
+        type: string
+        default: "15m"
+      nginx_build_context:
+        description: "Path to be used as build context for Nginx image build."
+        type: string
+        default: "web"
+      source_chart:
+        description: "Chart to extend"
+        type: string
+        default: ''
+      extension_file:
+        description: "Extension config for the source chart"
+        type: string
+        default: ''
+    working_directory: ~/project/<<parameters.drupal-root>>
+    steps:
+      - checkout:
+          path: ~/project
+      - silta-cli-setup
+      - steps: <<parameters.codebase-build>>
+      - unless:
+          condition: <<parameters.skip-deployment>>
+          steps:
+            - when:
+                condition: <<parameters.decrypt_files>>
+                steps:
+                  - decrypt-files:
+                      files: <<parameters.decrypt_files>>
+            - docker-setup
+            - silta-setup:
+                release-suffix: '<<parameters.release-suffix>>'
+            - drupal-docker-build:
+                nginx_build_context: <<parameters.nginx_build_context>>
+            - run:
+                name: Store container image URLs to workspace
+                command: |
+                  echo "php_IMAGE_URL='$php_IMAGE_URL'" >> tags
+                  echo "nginx_IMAGE_URL='$nginx_IMAGE_URL'" >> tags
+                  echo "shell_IMAGE_URL='$shell_IMAGE_URL'" >> tags
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - tags
+
+  drupal-deploy:
+    description: "Deploy drupal chart release."
+    executor: <<parameters.executor>>
+    resource_class: small
+    parameters:
+      executor:
+        description: "The name of custom executor to use."
+        type: executor
+        default: silta
+      drupal-root:
+        description: "Relative path to drupal root"
+        type: string
+        default: "."
+      codebase-build:
+        description: "Preparational build steps run after code checkout."
+        type: steps
+        default: []
+      pre-release:
+        description: "Steps to be executed before the Helm release is created."
+        type: steps
+        default: []
+      chart_name:
+        description: "Helm chart name."
+        type: string
+        default: drupal
+      chart_version:
+        description: "Deploy specific drupal helm chart version."
+        type: string
+        default: ""
+      chart_repository:
+        description: "Helm chart repository."
+        type: string
+        default: https://storage.googleapis.com/charts.wdr.io
+      decrypt_files:
+        description: "Encrypted value files. Can have multiple, comma separated values."
+        type: string
+        default: ""
+      silta_config:
+        description: "Chart values override file. Can have multiple, comma separated values."
+        type: string
+        default: "silta/silta.yml"
+      skip-deployment:
+        description: "Skip release deployment."
+        type: boolean
+        default: false
+      cluster_domain:
+        description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
+        type: env_var_name
+        default: CLUSTER_DOMAIN
+      release-suffix:
+        description: "Release name suffix."
+        type: string
+        default: ''
+      deployment_timeout:
+        description: "Helm release deployment timeout."
+        type: string
+        default: "15m"
+      nginx_build_context:
+        description: "Path to be used as build context for Nginx image build."
+        type: string
+        default: "web"
+      source_chart:
+        description: "Chart to extend"
+        type: string
+        default: ''
+      extension_file:
+        description: "Extension config for the source chart"
+        type: string
+        default: ''
+    working_directory: ~/project/<<parameters.drupal-root>>
+    steps:
+      - checkout:
+          path: ~/project
+      - silta-cli-setup
+      - unless:
+          condition: <<parameters.skip-deployment>>
+          steps:
+            - when:
+                condition: <<parameters.decrypt_files>>
+                steps:
+                  - decrypt-files:
+                      files: <<parameters.decrypt_files>>
+            - silta-setup:
+                release-suffix: '<<parameters.release-suffix>>'
+            - steps: <<parameters.pre-release>>
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                name: Set tags from workspace
+                command: |
+                  source /tmp/workspace/tags
+                  echo "export php_IMAGE_URL='$php_IMAGE_URL'" >> "$BASH_ENV"
+                  echo "export nginx_IMAGE_URL='$nginx_IMAGE_URL'" >> "$BASH_ENV"
+                  echo "export shell_IMAGE_URL='$shell_IMAGE_URL'" >> "$BASH_ENV"
+            - extend-helm-chart:
+                source_chart: '<<parameters.source_chart>>'
+                extension_file: '<<parameters.extension_file>>'
+                chart_version: '<<parameters.chart_version>>'
+            - drupal-values-validate:
+                chart_name: <<parameters.chart_name>>
+                chart_version: <<parameters.chart_version>>
+                chart_repository: <<parameters.chart_repository>>
+                silta_config: <<parameters.silta_config>>
+            - drupal-helm-deploy:
+                chart_name: <<parameters.chart_name>>
+                chart_version: <<parameters.chart_version>>
+                chart_repository: <<parameters.chart_repository>>
+                silta_config: <<parameters.silta_config>>
+                cluster_domain: <<parameters.cluster_domain>>
+                deployment_timeout: <<parameters.deployment_timeout>>

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -224,7 +224,7 @@ drupal-build-deploy-dev-charts:
       default: ""
 
 drupal-build:
-  description: "Build Drupal chart release."
+  description: "Build codebase and Docker images for a Drupal release."
   executor: <<parameters.executor>>
   resource_class: <<parameters.resource_class>>
   parameters:
@@ -302,7 +302,7 @@ drupal-build:
                 - tags
 
 drupal-deploy: &drupal-deploy
-  description: "Deploy drupal chart release."
+  description: "Deploy Drupal chart release."
   executor: <<parameters.executor>>
   resource_class: <<parameters.resource_class>>
   parameters: &drupal-deploy-params

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -261,6 +261,14 @@ drupal-build:
       description: "Path to be used as build context for Nginx image build."
       type: string
       default: "web"
+    image_build_background:
+      type: boolean
+      default: true
+      description: "Run docker build in background."
+    image_build_wait:
+      type: boolean
+      default: true
+      description: "Wait for docker build to finish."
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -280,6 +288,8 @@ drupal-build:
               release-suffix: '<<parameters.release-suffix>>'
           - drupal-docker-build:
               nginx_build_context: <<parameters.nginx_build_context>>
+              background: <<parameters.image_build_background>>
+              wait: <<parameters.image_build_wait>>
           - run:
               name: Store container image URLs to workspace
               command: |

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -301,11 +301,11 @@ drupal-build:
               paths:
                 - tags
 
-drupal-deploy:
+drupal-deploy: &drupal-deploy
   description: "Deploy drupal chart release."
   executor: <<parameters.executor>>
   resource_class: <<parameters.resource_class>>
-  parameters:
+  parameters: &drupal-deploy-params
     executor:
       description: "The name of custom executor to use."
       type: executor
@@ -366,6 +366,10 @@ drupal-deploy:
       description: "Extension config for the source chart"
       type: string
       default: ''
+    use_dev_chart:
+      description: "Internal use only. Used by drupal-build-deploy-dev-charts."
+      type: boolean
+      default: false
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -374,6 +378,10 @@ drupal-deploy:
     - unless:
         condition: <<parameters.skip-deployment>>
         steps:
+          - when:
+              condition: <<parameters.use_dev_chart>>
+              steps:
+                - drupal-download-dev-chart
           - when:
               condition: <<parameters.decrypt_files>>
               steps:
@@ -407,3 +415,23 @@ drupal-deploy:
               silta_config: <<parameters.silta_config>>
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
+
+# Job to deploy using development charts. This extends the
+# drupal-deploy job and overrides some of the parameters.
+drupal-deploy-dev-charts:
+  <<: *drupal-deploy
+  description: "Deploy using development charts."
+  parameters:
+    <<: *drupal-deploy-params
+    use_dev_chart:
+      description: "Use development version of the Drupal chart."
+      type: boolean
+      default: true
+    chart_name:
+      description: "Helm chart name."
+      type: string
+      default: "./charts/drupal"
+    chart_repository:
+      description: "Helm chart repository."
+      type: string
+      default: ""

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -239,58 +239,22 @@ drupal-build:
       description: "Preparational build steps run after code checkout."
       type: steps
       default: []
-    pre-release:
-      description: "Steps to be executed before the Helm release is created."
-      type: steps
-      default: []
-    chart_name:
-      description: "Helm chart name."
-      type: string
-      default: drupal
-    chart_version:
-      description: "Deploy specific drupal helm chart version."
-      type: string
-      default: ""
-    chart_repository:
-      description: "Helm chart repository."
-      type: string
-      default: https://storage.googleapis.com/charts.wdr.io
     decrypt_files:
       description: "Encrypted value files. Can have multiple, comma separated values."
       type: string
       default: ""
-    silta_config:
-      description: "Chart values override file. Can have multiple, comma separated values."
-      type: string
-      default: "silta/silta.yml"
     skip-deployment:
       description: "Skip release deployment."
       type: boolean
       default: false
-    cluster_domain:
-      description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
-      type: env_var_name
-      default: CLUSTER_DOMAIN
     release-suffix:
       description: "Release name suffix."
       type: string
       default: ''
-    deployment_timeout:
-      description: "Helm release deployment timeout."
-      type: string
-      default: "15m"
     nginx_build_context:
       description: "Path to be used as build context for Nginx image build."
       type: string
       default: "web"
-    source_chart:
-      description: "Chart to extend"
-      type: string
-      default: ''
-    extension_file:
-      description: "Extension config for the source chart"
-      type: string
-      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -334,10 +298,6 @@ drupal-deploy:
       description: "Relative path to drupal root"
       type: string
       default: "."
-    codebase-build:
-      description: "Preparational build steps run after code checkout."
-      type: steps
-      default: []
     pre-release:
       description: "Steps to be executed before the Helm release is created."
       type: steps
@@ -378,10 +338,6 @@ drupal-deploy:
       description: "Helm release deployment timeout."
       type: string
       default: "15m"
-    nginx_build_context:
-      description: "Path to be used as build context for Nginx image build."
-      type: string
-      default: "web"
     source_chart:
       description: "Chart to extend"
       type: string

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -193,6 +193,7 @@ drupal-build-deploy: &drupal-build-deploy
               steps:
                 - decrypt-files:
                     files: <<parameters.decrypt_files>>
+          - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
           - extend-helm-chart:

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -223,211 +223,211 @@ drupal-build-deploy-dev-charts:
       type: string
       default: ""
 
-  drupal-build:
-    description: "Build Drupal chart release."
-    executor: <<parameters.executor>>
-    parameters:
-      executor:
-        description: "The name of custom executor to use."
-        type: executor
-        default: silta
-      drupal-root:
-        description: "Relative path to drupal root"
-        type: string
-        default: "."
-      codebase-build:
-        description: "Preparational build steps run after code checkout."
-        type: steps
-        default: []
-      pre-release:
-        description: "Steps to be executed before the Helm release is created."
-        type: steps
-        default: []
-      chart_name:
-        description: "Helm chart name."
-        type: string
-        default: drupal
-      chart_version:
-        description: "Deploy specific drupal helm chart version."
-        type: string
-        default: ""
-      chart_repository:
-        description: "Helm chart repository."
-        type: string
-        default: https://storage.googleapis.com/charts.wdr.io
-      decrypt_files:
-        description: "Encrypted value files. Can have multiple, comma separated values."
-        type: string
-        default: ""
-      silta_config:
-        description: "Chart values override file. Can have multiple, comma separated values."
-        type: string
-        default: "silta/silta.yml"
-      skip-deployment:
-        description: "Skip release deployment."
-        type: boolean
-        default: false
-      cluster_domain:
-        description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
-        type: env_var_name
-        default: CLUSTER_DOMAIN
-      release-suffix:
-        description: "Release name suffix."
-        type: string
-        default: ''
-      deployment_timeout:
-        description: "Helm release deployment timeout."
-        type: string
-        default: "15m"
-      nginx_build_context:
-        description: "Path to be used as build context for Nginx image build."
-        type: string
-        default: "web"
-      source_chart:
-        description: "Chart to extend"
-        type: string
-        default: ''
-      extension_file:
-        description: "Extension config for the source chart"
-        type: string
-        default: ''
-    working_directory: ~/project/<<parameters.drupal-root>>
-    steps:
-      - checkout:
-          path: ~/project
-      - silta-cli-setup
-      - steps: <<parameters.codebase-build>>
-      - unless:
-          condition: <<parameters.skip-deployment>>
-          steps:
-            - when:
-                condition: <<parameters.decrypt_files>>
-                steps:
-                  - decrypt-files:
-                      files: <<parameters.decrypt_files>>
-            - docker-setup
-            - silta-setup:
-                release-suffix: '<<parameters.release-suffix>>'
-            - drupal-docker-build:
-                nginx_build_context: <<parameters.nginx_build_context>>
-            - run:
-                name: Store container image URLs to workspace
-                command: |
-                  echo "php_IMAGE_URL='$php_IMAGE_URL'" >> tags
-                  echo "nginx_IMAGE_URL='$nginx_IMAGE_URL'" >> tags
-                  echo "shell_IMAGE_URL='$shell_IMAGE_URL'" >> tags
-            - persist_to_workspace:
-                root: .
-                paths:
-                  - tags
+drupal-build:
+  description: "Build Drupal chart release."
+  executor: <<parameters.executor>>
+  parameters:
+    executor:
+      description: "The name of custom executor to use."
+      type: executor
+      default: silta
+    drupal-root:
+      description: "Relative path to drupal root"
+      type: string
+      default: "."
+    codebase-build:
+      description: "Preparational build steps run after code checkout."
+      type: steps
+      default: []
+    pre-release:
+      description: "Steps to be executed before the Helm release is created."
+      type: steps
+      default: []
+    chart_name:
+      description: "Helm chart name."
+      type: string
+      default: drupal
+    chart_version:
+      description: "Deploy specific drupal helm chart version."
+      type: string
+      default: ""
+    chart_repository:
+      description: "Helm chart repository."
+      type: string
+      default: https://storage.googleapis.com/charts.wdr.io
+    decrypt_files:
+      description: "Encrypted value files. Can have multiple, comma separated values."
+      type: string
+      default: ""
+    silta_config:
+      description: "Chart values override file. Can have multiple, comma separated values."
+      type: string
+      default: "silta/silta.yml"
+    skip-deployment:
+      description: "Skip release deployment."
+      type: boolean
+      default: false
+    cluster_domain:
+      description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
+      type: env_var_name
+      default: CLUSTER_DOMAIN
+    release-suffix:
+      description: "Release name suffix."
+      type: string
+      default: ''
+    deployment_timeout:
+      description: "Helm release deployment timeout."
+      type: string
+      default: "15m"
+    nginx_build_context:
+      description: "Path to be used as build context for Nginx image build."
+      type: string
+      default: "web"
+    source_chart:
+      description: "Chart to extend"
+      type: string
+      default: ''
+    extension_file:
+      description: "Extension config for the source chart"
+      type: string
+      default: ''
+  working_directory: ~/project/<<parameters.drupal-root>>
+  steps:
+    - checkout:
+        path: ~/project
+    - silta-cli-setup
+    - steps: <<parameters.codebase-build>>
+    - unless:
+        condition: <<parameters.skip-deployment>>
+        steps:
+          - when:
+              condition: <<parameters.decrypt_files>>
+              steps:
+                - decrypt-files:
+                    files: <<parameters.decrypt_files>>
+          - docker-setup
+          - silta-setup:
+              release-suffix: '<<parameters.release-suffix>>'
+          - drupal-docker-build:
+              nginx_build_context: <<parameters.nginx_build_context>>
+          - run:
+              name: Store container image URLs to workspace
+              command: |
+                echo "php_IMAGE_URL='$php_IMAGE_URL'" >> tags
+                echo "nginx_IMAGE_URL='$nginx_IMAGE_URL'" >> tags
+                echo "shell_IMAGE_URL='$shell_IMAGE_URL'" >> tags
+          - persist_to_workspace:
+              root: .
+              paths:
+                - tags
 
-  drupal-deploy:
-    description: "Deploy drupal chart release."
-    executor: <<parameters.executor>>
-    resource_class: small
-    parameters:
-      executor:
-        description: "The name of custom executor to use."
-        type: executor
-        default: silta
-      drupal-root:
-        description: "Relative path to drupal root"
-        type: string
-        default: "."
-      codebase-build:
-        description: "Preparational build steps run after code checkout."
-        type: steps
-        default: []
-      pre-release:
-        description: "Steps to be executed before the Helm release is created."
-        type: steps
-        default: []
-      chart_name:
-        description: "Helm chart name."
-        type: string
-        default: drupal
-      chart_version:
-        description: "Deploy specific drupal helm chart version."
-        type: string
-        default: ""
-      chart_repository:
-        description: "Helm chart repository."
-        type: string
-        default: https://storage.googleapis.com/charts.wdr.io
-      decrypt_files:
-        description: "Encrypted value files. Can have multiple, comma separated values."
-        type: string
-        default: ""
-      silta_config:
-        description: "Chart values override file. Can have multiple, comma separated values."
-        type: string
-        default: "silta/silta.yml"
-      skip-deployment:
-        description: "Skip release deployment."
-        type: boolean
-        default: false
-      cluster_domain:
-        description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
-        type: env_var_name
-        default: CLUSTER_DOMAIN
-      release-suffix:
-        description: "Release name suffix."
-        type: string
-        default: ''
-      deployment_timeout:
-        description: "Helm release deployment timeout."
-        type: string
-        default: "15m"
-      nginx_build_context:
-        description: "Path to be used as build context for Nginx image build."
-        type: string
-        default: "web"
-      source_chart:
-        description: "Chart to extend"
-        type: string
-        default: ''
-      extension_file:
-        description: "Extension config for the source chart"
-        type: string
-        default: ''
-    working_directory: ~/project/<<parameters.drupal-root>>
-    steps:
-      - checkout:
-          path: ~/project
-      - silta-cli-setup
-      - unless:
-          condition: <<parameters.skip-deployment>>
-          steps:
-            - when:
-                condition: <<parameters.decrypt_files>>
-                steps:
-                  - decrypt-files:
-                      files: <<parameters.decrypt_files>>
-            - silta-setup:
-                release-suffix: '<<parameters.release-suffix>>'
-            - steps: <<parameters.pre-release>>
-            - attach_workspace:
-                at: /tmp/workspace
-            - run:
-                name: Set tags from workspace
-                command: |
-                  source /tmp/workspace/tags
-                  echo "export php_IMAGE_URL='$php_IMAGE_URL'" >> "$BASH_ENV"
-                  echo "export nginx_IMAGE_URL='$nginx_IMAGE_URL'" >> "$BASH_ENV"
-                  echo "export shell_IMAGE_URL='$shell_IMAGE_URL'" >> "$BASH_ENV"
-            - extend-helm-chart:
-                source_chart: '<<parameters.source_chart>>'
-                extension_file: '<<parameters.extension_file>>'
-                chart_version: '<<parameters.chart_version>>'
-            - drupal-values-validate:
-                chart_name: <<parameters.chart_name>>
-                chart_version: <<parameters.chart_version>>
-                chart_repository: <<parameters.chart_repository>>
-                silta_config: <<parameters.silta_config>>
-            - drupal-helm-deploy:
-                chart_name: <<parameters.chart_name>>
-                chart_version: <<parameters.chart_version>>
-                chart_repository: <<parameters.chart_repository>>
-                silta_config: <<parameters.silta_config>>
-                cluster_domain: <<parameters.cluster_domain>>
-                deployment_timeout: <<parameters.deployment_timeout>>
+drupal-deploy:
+  description: "Deploy drupal chart release."
+  executor: <<parameters.executor>>
+  resource_class: small
+  parameters:
+    executor:
+      description: "The name of custom executor to use."
+      type: executor
+      default: silta
+    drupal-root:
+      description: "Relative path to drupal root"
+      type: string
+      default: "."
+    codebase-build:
+      description: "Preparational build steps run after code checkout."
+      type: steps
+      default: []
+    pre-release:
+      description: "Steps to be executed before the Helm release is created."
+      type: steps
+      default: []
+    chart_name:
+      description: "Helm chart name."
+      type: string
+      default: drupal
+    chart_version:
+      description: "Deploy specific drupal helm chart version."
+      type: string
+      default: ""
+    chart_repository:
+      description: "Helm chart repository."
+      type: string
+      default: https://storage.googleapis.com/charts.wdr.io
+    decrypt_files:
+      description: "Encrypted value files. Can have multiple, comma separated values."
+      type: string
+      default: ""
+    silta_config:
+      description: "Chart values override file. Can have multiple, comma separated values."
+      type: string
+      default: "silta/silta.yml"
+    skip-deployment:
+      description: "Skip release deployment."
+      type: boolean
+      default: false
+    cluster_domain:
+      description: "Cluster domain value for helm chart. Will be used for default ingress hostnames."
+      type: env_var_name
+      default: CLUSTER_DOMAIN
+    release-suffix:
+      description: "Release name suffix."
+      type: string
+      default: ''
+    deployment_timeout:
+      description: "Helm release deployment timeout."
+      type: string
+      default: "15m"
+    nginx_build_context:
+      description: "Path to be used as build context for Nginx image build."
+      type: string
+      default: "web"
+    source_chart:
+      description: "Chart to extend"
+      type: string
+      default: ''
+    extension_file:
+      description: "Extension config for the source chart"
+      type: string
+      default: ''
+  working_directory: ~/project/<<parameters.drupal-root>>
+  steps:
+    - checkout:
+        path: ~/project
+    - silta-cli-setup
+    - unless:
+        condition: <<parameters.skip-deployment>>
+        steps:
+          - when:
+              condition: <<parameters.decrypt_files>>
+              steps:
+                - decrypt-files:
+                    files: <<parameters.decrypt_files>>
+          - silta-setup:
+              release-suffix: '<<parameters.release-suffix>>'
+          - steps: <<parameters.pre-release>>
+          - attach_workspace:
+              at: /tmp/workspace
+          - run:
+              name: Set tags from workspace
+              command: |
+                source /tmp/workspace/tags
+                echo "export php_IMAGE_URL='$php_IMAGE_URL'" >> "$BASH_ENV"
+                echo "export nginx_IMAGE_URL='$nginx_IMAGE_URL'" >> "$BASH_ENV"
+                echo "export shell_IMAGE_URL='$shell_IMAGE_URL'" >> "$BASH_ENV"
+          - extend-helm-chart:
+              source_chart: '<<parameters.source_chart>>'
+              extension_file: '<<parameters.extension_file>>'
+              chart_version: '<<parameters.chart_version>>'
+          - drupal-values-validate:
+              chart_name: <<parameters.chart_name>>
+              chart_version: <<parameters.chart_version>>
+              chart_repository: <<parameters.chart_repository>>
+              silta_config: <<parameters.silta_config>>
+          - drupal-helm-deploy:
+              chart_name: <<parameters.chart_name>>
+              chart_version: <<parameters.chart_version>>
+              chart_repository: <<parameters.chart_repository>>
+              silta_config: <<parameters.silta_config>>
+              cluster_domain: <<parameters.cluster_domain>>
+              deployment_timeout: <<parameters.deployment_timeout>>

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -67,6 +67,7 @@ frontend-build-deploy:
 
     - steps: <<parameters.codebase-build>>
 
+    - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
 

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -73,6 +73,7 @@ simple-build-deploy:
 
     - steps: <<parameters.codebase-build>>
 
+    - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
 


### PR DESCRIPTION
Changes proposed:
- Extracts the `setup_remote_docker` step from `silta-setup` into its own command
- Adds two new jobs: `drupal-build` and `drupal-deploy`, which intend to eventually replace the `drupal-build-deploy` job

Out of these new jobs, only `drupal-build` needs `setup_remote_docker`, which causes that job to automatically use machine types of `Remote Docker`. The smallest available resource class for those machines is `Medium`.

This allows us to use the normal machine type `Docker` for the `drupal-deploy` job. The smallest available resource class for those machines is `Small`, which is half of the cost of the `Remote Docker / Medium` machines.

Initial tests indicate that while this change might add a bit to total deployment time, it on the other hand uses considerably less of CircleCi credits.