### PR TITLE
Declare resource_class for custom job(s) in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ orbs:
 
 jobs:
   validate:
+    resource_class: small
     docker:
       - image: cimg/node:lts
     steps:


### PR DESCRIPTION
This PR declares a resource_class for the custom job(s) in your CircleCI config.

Use the smallest possible option that works for your job, as the cost between small, medium and large doubles in size with each option. If your job fails due to lack of memory, try increasing the resource_class or optimizing your code if possible.

See the specs and cost for each option at https://circleci.com/product/features/resource-classes/#docker

The resource_class can be seen in CircleCI UI when clicking the job. You can also see how much CPU and RAM the job is using. See example screenshot:

![Alt text](https://monosnap.com/image/NhEGFIeBKnZIPmB3bN7kVxnoiZP6kN)


CircleCI docs state:

> If a resource_class is not explicitly declared for a job, CircleCI will use a default resource class size. Defaults are subject to change. It is best practice to specify a resource class, rather than relying on a default.