### PR TITLE
Post release step

### DIFF
--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -220,7 +220,7 @@ drupal-build-deploy: &drupal-build-deploy
               silta_config: <<parameters.silta_config>>
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
-          - post-release: <<parameters.post-release>>
+          - steps: <<parameters.post-release>>
 
 # Job to build and deploy using development charts. This extends the
 # drupal-build-deploy job and overrides some of the parameters.

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -115,6 +115,10 @@ drupal-build-deploy: &drupal-build-deploy
       description: "Steps to be executed before the Helm release is created."
       type: steps
       default: []
+    post-release:
+      description: "Steps to be executed after the Helm release is created."
+      type: steps
+      default: []
     chart_name:
       description: "Helm chart name."
       type: string
@@ -216,6 +220,8 @@ drupal-build-deploy: &drupal-build-deploy
               silta_config: <<parameters.silta_config>>
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
+          - post-release:
+              steps: <<parameters.post-release>>
 
 # Job to build and deploy using development charts. This extends the
 # drupal-build-deploy job and overrides some of the parameters.

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -220,8 +220,7 @@ drupal-build-deploy: &drupal-build-deploy
               silta_config: <<parameters.silta_config>>
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
-          - post-release:
-              steps: <<parameters.post-release>>
+          - post-release: <<parameters.post-release>>
 
 # Job to build and deploy using development charts. This extends the
 # drupal-build-deploy job and overrides some of the parameters.

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -122,4 +122,4 @@ simple-build-deploy:
                   --silta-config "<<parameters.silta_config>>"
 
           - helm-release-information
-          - post-release: <<parameters.post-release>>
+          - steps: <<parameters.post-release>>

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -122,5 +122,4 @@ simple-build-deploy:
                   --silta-config "<<parameters.silta_config>>"
 
           - helm-release-information
-          - post-release:
-              steps: <<parameters.post-release>>
+          - post-release: <<parameters.post-release>>

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -52,6 +52,10 @@ simple-build-deploy:
       description: "Steps to be executed before the Helm release is created."
       type: steps
       default: []
+    post-release:
+      description: "Steps to be executed after the Helm release is created."
+      type: steps
+      default: []
     release-suffix:
       description: "Release name suffix."
       type: string
@@ -118,3 +122,5 @@ simple-build-deploy:
                   --silta-config "<<parameters.silta_config>>"
 
           - helm-release-information
+          - post-release:
+              steps: <<parameters.post-release>>


### PR DESCRIPTION
### Add post release steps to Simple and Drupal jobs.

**Motivation:**
1. Currently there are edge cases when application rollout is too slow and the time between cache clear and actual updated images are spun up is too large so we need to do additional steps once we know that all replicas have been rolled out. (Error is created for client after each new plugin deployment + template changes since cache clear just cleans cache, but if someone accesses old pod then old cache is regenerated)
2. We already have pre-release steps so makes sense that we add pos-release "hook"
3. In future this allows additionally run any step like:
    - Send notifications in same step instead of creating dependant job
    - Make additional deployment validations
    - Run create tunnels and run test only if deployment is successful
    - Trigger other web hooks.
    - Etc.

**How it works:**
```  - silta/drupal-build-deploy:
          name: build-deploy-myproject
          post-release:
            - run: kubectl exec -it deploy/${RELEASE_NAME}-shell -n ${CIRCLE_PROJECT_REPONAME,,} -- drush cr
            - run: vendor/bin/codecept run -g ${RELEASE_NAME}
            - run: curl --output /dev/null --silent --head --fail "https://mysite.com";
 ```