### PR TITLE
Test builds via circleci api v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,42 +11,66 @@ jobs:
     steps:
       - test-project:
           project: drupal-project-k8s
-          job_count: 2
       - test-project:
           project: frontend-project-k8s
-          job_count: 2
       - test-project:
           project: simple-project-k8s
-          job_count: 1
 
 commands:
   test-project:
     parameters:
+      org:
+        type: string
+        default: wunderio
       project:
         type: string
-      job_count:
-        type: integer
-        description: The expected number of jobs.
+      branch:
+        type: string
+        default: master
     steps:
       - run:
           name: Validate orb with <<parameters.project>>
           command: |
-            base_api_url="https://circleci.com/api/v1.1/project/github/wunderio/<<parameters.project>>"
 
-            # Trigger a new deployment.
-            curl -s -X POST $base_api_url/build?circle-token=$CIRCLECI_DEV_API_TOKEN
+            REPO_NAME="<<parameters.project>>"
+            ORG_NAME="<<parameters.org>>"
+            BRANCH_NAME="<<parameters.branch>>"
+            CIRCLECI_DEV_API_TOKEN_B64=$(echo -n "${CIRCLECI_DEV_API_TOKEN}:" | base64)
+
+            if [ -z "${CIRCLECI_DEV_API_TOKEN}" ]; then
+              echo "Repository secrets is missing CIRCLECI_DEV_API_TOKEN variable."
+              exit 1
+            fi
+
+            echo "Running ${ORG_NAME}/${REPO_NAME}/${BRANCH_NAME} build on CircleCI"
+            echo "Project link: https://app.circleci.com/pipelines/github/${ORG_NAME}/${REPO_NAME}?branch=${BRANCH_NAME}"
+
+            # Trigger a new pipeline
+            PIPELINE_ID=$(curl --request POST \
+              --url "https://circleci.com/api/v2/project/gh/wunderio/${REPO_NAME}/pipeline" \
+              --header "content-type: application/json" \
+              --data "{\"branch\":\"${BRANCH_NAME}\"}" \
+              --header "authorization: Basic ${CIRCLECI_DEV_API_TOKEN_B64}" --silent | jq -r '.id')
+
+            echo "Pipeline ID: ${PIPELINE_ID}"
+
             sleep 10
 
-            # Wait for deployment to be complete
-            while curl -s "$base_api_url?circle-token=$CIRCLECI_DEV_API_TOKEN&limit=<<parameters.job_count>>" | jq -e 'any(.[]; (.status == "running") or (.status == "queued"))' > /dev/null
-            do
-              echo "still running"
+            # Wait for pipeline to complete
+            while true; do
+              PIPELINE_STATUS=$(curl --request GET \
+                --url "https://circleci.com/api/v2/pipeline/${PIPELINE_ID}/workflow" \
+                --header "authorization: Basic ${CIRCLECI_DEV_API_TOKEN_B64}" --silent | jq -r '.items[0].status')
+              if [ "${PIPELINE_STATUS}" = "success" ]; then
+                echo "Pipeline completed successfully"
+                break
+              elif [ "${PIPELINE_STATUS}" != "created" ] && [ "${PIPELINE_STATUS}" != "running" ]; then
+                echo "Pipeline status: ${PIPELINE_STATUS}, failing the test"
+                exit 1
+              fi
+              echo "current status: ${PIPELINE_STATUS}"
               sleep 10
             done
-
-            # Test that the build was successful
-            curl -s "$base_api_url?circle-token=$CIRCLECI_DEV_API_TOKEN&limit=<<parameters.job_count>>" | jq '.[] | { job_name: .workflows.job_name, status: .status }'
-            curl -s "$base_api_url?circle-token=$CIRCLECI_DEV_API_TOKEN&limit=<<parameters.job_count>>" | jq -e 'all(.[]; .status == "success")' > /dev/null
 
 workflows:
   btd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,9 @@ workflows:
       - validate: &validate
           requires:
             - "Publish development orb"
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
 
   weekly-dev-publish:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,9 @@ workflows:
       - validate: &validate
           requires:
             - "Publish development orb"
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
 
   weekly-dev-publish:
     triggers:


### PR DESCRIPTION
Triggered pipeline id is used for build status check instead of using the last pipeline. This will fix concurrent validations. 
Build example (removed in cleanup commit): https://app.circleci.com/pipelines/github/wunderio/silta-circleci/1044/workflows/96509ec8-49b7-4b34-9405-2941e2c1514b/jobs/1295