### PR TITLE
Set proxy only for kubernetes cluster connections

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -261,19 +261,18 @@ set-up-socks-proxy:
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
           fi
     - run:
-        name: Open up a tunnel
+        name: Proxy setup for cluster connections
         command: |
           if [[ -n "$TUNNEL_USER_HOST" ]]; then
             ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
-            echo 'export HTTPS_PROXY=socks5://localhost:1337' >> $BASH_ENV
+            echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
             if command -v gcloud &> /dev/null; then
               gcloud config set proxy/type socks5
               gcloud config set proxy/address 127.0.0.1
               gcloud config set proxy/port 1337
             fi
-            if command -v yarn &> /dev/null; then
-              yarn config set proxy socks5://127.0.0.1:1337
-              yarn config set https-proxy socks5://127.0.0.1:1337
+            if command -v silta &> /dev/null; then
+              silta config set proxy socks5://localhost:1337
             fi
             echo "Proxy is ready for outgoing connections"
           fi

--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -150,20 +150,6 @@ drupal-helm-deploy:
   steps:
     - helm-cleanup
     - run:
-        name: Special updates
-        command: |
-          function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
-
-          if [[ -n "$CURRENT_CHART_VERSION" ]] && [[ "$CURRENT_CHART_VERSION" = drupal-* ]]
-          then
-            if version_lt "$CURRENT_CHART_VERSION" "drupal-0.3.43"
-            then
-              echo "Recreating statefulset for Mariadb subchart update to 7.x."
-              kubectl delete statefulset --cascade=false "$RELEASE_NAME-mariadb" -n "$NAMESPACE"
-            fi
-          fi
-
-    - run:
         name: Deploy helm release
         no_output_timeout: '<<parameters.deployment_timeout>>'
         command: |
@@ -197,16 +183,6 @@ drupal-helm-deploy:
             --namespace "${NAMESPACE}" \
             --silta-config "<<parameters.silta_config>>" \
             --deployment-timeout "<<parameters.deployment_timeout>>"
-
-    - run:
-        name: Wait for resources to be ready
-        command: |
-          # Get all deployments and statefulsets in the release and check the status of each one.
-          statefulsets=$(kubectl get statefulset -n "$NAMESPACE" -l "release=${RELEASE_NAME}" -o name)
-          if [ ! -z "$statefulsets" ]; then
-            echo "$statefulsets" | xargs -n 1 kubectl rollout status -n "$NAMESPACE"
-          fi
-          kubectl get deployment -n "$NAMESPACE" -l "release=${RELEASE_NAME}" -o name | xargs -n 1 kubectl rollout status -n "$NAMESPACE"
 
     - helm-release-information
 

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -284,11 +284,17 @@ drupal-build:
       type: boolean
       default: true
       description: "Wait for docker build to finish."
+    silta_cli_version:
+      description: "Version of silta-cli to use."
+      type: enum
+      enum: [ "latest", "test" ]
+      default: "latest"
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
         path: ~/project
-    - silta-cli-setup
+    - silta-cli-setup:
+        version: <<parameters.silta_cli_version>>
     - steps: <<parameters.codebase-build>>
     - unless:
         condition: <<parameters.skip-deployment>>

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -61,9 +61,15 @@ frontend-build-deploy:
       description: "Extension config for the source chart"
       type: string
       default: ''
+    silta_cli_version:
+      description: "Version of silta-cli to use."
+      type: enum
+      enum: [ "latest", "test" ]
+      default: "latest"
   steps:
     - checkout
-    - silta-cli-setup
+    - silta-cli-setup:
+        version: <<parameters.silta_cli_version>>
 
     - steps: <<parameters.codebase-build>>
 

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -64,12 +64,18 @@ simple-build-deploy:
       description: "Extension config for the source chart"
       type: string
       default: ''
+    silta_cli_version:
+      description: "Version of silta-cli to use."
+      type: enum
+      enum: [ "latest", "test" ]
+      default: "latest"
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:
         path: ~/project
 
-    - silta-cli-setup
+    - silta-cli-setup:
+        version: <<parameters.silta_cli_version>>
 
     - steps: <<parameters.codebase-build>>
 


### PR DESCRIPTION
## Blocked by https://github.com/wunderio/silta-cli/pull/61, do not merge until cli binaries are built

Last attempt to use proxy caused some nodejs project build issues. This change sets proxy only for kubernetes cluster connections which should fix it. 

Testing - both deployments have to be green. Drupal fails due to drupal-deploy command initializing tunnel before cli can be downloaded (there is no pre-step to inject test cli download).
1. https://github.com/wunderio/drupal-project-k8s/tree/feature/test-cluster/proxy-test
2. https://github.com/wunderio/frontend-project-k8s/tree/feature/test-cluster/proxy-test