### PR TITLE
Repo name added to chart name to avoid path collisions

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -233,13 +233,9 @@ drupal-values-validate:
           if [[ ! -z "<<parameters.chart_version>>" ]] ; then
             version="--chart-version <<parameters.chart_version>>"
           fi
-          if [[ ! -z "<<parameters.chart_repository>>" ]] ; then
-            repo="--chart-repository <<parameters.chart_repository>>"
-          fi
-
           silta ci release validate --chart-name '<<parameters.chart_name>>' \
-          $repo \
           $version \
+          --chart-repository '<<parameters.chart_repository>>' \
           --namespace "$NAMESPACE" \
           --release-name "$RELEASE_NAME" \
           --silta-config '<<parameters.silta_config>>' \

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -118,7 +118,7 @@ drupal-build-deploy: &drupal-build-deploy
     chart_name:
       description: "Helm chart name."
       type: string
-      default: drupal
+      default: wunderio/drupal
     chart_version:
       description: "Deploy specific drupal helm chart version."
       type: string
@@ -126,7 +126,7 @@ drupal-build-deploy: &drupal-build-deploy
     chart_repository:
       description: "Helm chart repository."
       type: string
-      default: https://storage.googleapis.com/charts.wdr.io
+      default: ""
     use_dev_chart:
       description: "Internal use only. Used by drupal-build-deploy-dev-charts."
       type: boolean
@@ -340,7 +340,7 @@ drupal-deploy: &drupal-deploy
     chart_name:
       description: "Helm chart name."
       type: string
-      default: drupal
+      default: wunderio/drupal
     chart_version:
       description: "Deploy specific drupal helm chart version."
       type: string
@@ -348,7 +348,7 @@ drupal-deploy: &drupal-deploy
     chart_repository:
       description: "Helm chart repository."
       type: string
-      default: https://storage.googleapis.com/charts.wdr.io
+      default: ""
     decrypt_files:
       description: "Encrypted value files. Can have multiple, comma separated values."
       type: string

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -19,11 +19,11 @@ frontend-build-deploy:
     chart_name:
       description: "Helm chart name."
       type: string
-      default: frontend
+      default: wunderio/frontend
     chart_repository:
       description: "Helm chart repository."
       type: string
-      default: https://storage.googleapis.com/charts.wdr.io
+      default: ""
     chart_version:
       description: "Deploy specific simple helm chart version."
       type: string

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -19,11 +19,11 @@ simple-build-deploy:
     chart_name:
       description: "Helm chart name."
       type: string
-      default: simple
+      default: wunderio/simple
     chart_repository:
       description: "Helm chart repository."
       type: string
-      default: https://storage.googleapis.com/charts.wdr.io
+      default: ""
     chart_version:
       description: "Deploy specific simple helm chart version."
       type: string


### PR DESCRIPTION
Note: release only after https://github.com/wunderio/silta-cli/pull/60 is merged!

Appends repository name to chart name. This solves the issue where having a directory with name "simple", "frontend" or "drupal" in project folder would yield deployment issue. 
Related PR: https://github.com/wunderio/silta-cli/pull/60
This works as expected as chart name is covered by `hasSuffix`: https://github.com/wunderio/silta-cli/blob/master/cmd/ciReleaseDeploy.go#L403 
This was tested with all 3 charts.