### PR TITLE
QAG-24: Upgrade wunderio/code-quality Sonar scanner setup to v10.6

### DIFF
--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -19,7 +19,7 @@ analyze:
     - checkout
     - run: >-
         sonar-scanner -Dsonar.host.url="${SONAR_HOST}"
-        -Dsonar.login="${SONAR_TOKEN}"
+        -Dsonar.token="${SONAR_TOKEN}"
         -Dsonar.projectKey="${CIRCLE_PROJECT_REPONAME,,}"
         -Dsonar.sources='<<parameters.sources>>'
 


### PR DESCRIPTION
Changes:

- sonar.login is deprecated use sonar.token instead