### PR TITLE
Use pproxy for AWS clusters

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -275,7 +275,7 @@ set-up-socks-proxy:
               gcloud config set proxy/port 1337
             fi
             if command -v silta &> /dev/null; then
-              if [[ "$CLUSTER_TYPE" == "aws" ]] ; then 
+              if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
                 pproxy -r socks5://127.0.0.1:1337 --daemon
                 silta config set proxy http://localhost:8080
               else

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -275,7 +275,11 @@ set-up-socks-proxy:
               gcloud config set proxy/port 1337
             fi
             if command -v silta &> /dev/null; then
-              if [[ "$CLUSTER_TYPE" == "aws" ]] ; then
+              if [[ "$CLUSTER_TYPE" == "aws" ]] ; then 
+                sudo apt install python3-pip
+                sudo pip3 install pproxy
+                sudo pip3 install python-daemon
+                pproxy -r socks5://127.0.0.1:1337 --daemon
                 silta config set proxy http://localhost:8080
               else
                 silta config set proxy socks5://localhost:1337

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -276,6 +276,7 @@ set-up-socks-proxy:
             fi
             if command -v silta &> /dev/null; then
               if [[ "$CLUSTER_TYPE" == "aws" ]] ; then 
+                sudo apt-get update
                 sudo apt install python3-pip
                 sudo pip3 install pproxy
                 sudo pip3 install python-daemon

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -275,7 +275,11 @@ set-up-socks-proxy:
               gcloud config set proxy/port 1337
             fi
             if command -v silta &> /dev/null; then
-              silta config set proxy socks5://localhost:1337
+              if [[ "$CLUSTER_TYPE" == "aws" ]] ; then
+                silta config set proxy http://localhost:8080
+              else
+                silta config set proxy socks5://localhost:1337
+              fi
             fi
             echo "Proxy is ready for outgoing connections"
           fi

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -276,10 +276,6 @@ set-up-socks-proxy:
             fi
             if command -v silta &> /dev/null; then
               if [[ "$CLUSTER_TYPE" == "aws" ]] ; then 
-                sudo apt-get update
-                sudo apt install python3-pip
-                sudo pip3 install pproxy
-                sudo pip3 install python-daemon
                 pproxy -r socks5://127.0.0.1:1337 --daemon
                 silta config set proxy http://localhost:8080
               else


### PR DESCRIPTION
Enables an HTTP Proxy (pproxy) if aws cli is present. aws cli only supports http, but currently only socks5 protocol is supported in the image.
This PR sets localhost:8080 to be an HTTP protocol proxy, with pproxy serving as translation layer between http->socks5.
http*_proxy env vars will point to localhost:8080.