### PR TITLE
Add web-root parameter to drupal-composer-install command

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -29,6 +29,10 @@ drupal-composer-install:
       description: "CircleCI cache key prefix."
       type: string
       default: "v2"
+    web-root:
+      description: "Relative path to drupal webroot."
+      type: string
+      default: "web"
   steps:
     - when:
         # Install dev dependencies.
@@ -60,12 +64,12 @@ drupal-composer-install:
     - save_cache:
         paths:
           - ./vendor
-          - ./web/core
-          - ./web/modules/contrib
-          - ./web/themes/contrib
-          - ./web/profiles/contrib
-          - ./web/libraries
-          - ./web/_ping.php
+          - ./<<parameters.web-root>>/core
+          - ./<<parameters.web-root>>/modules/contrib
+          - ./<<parameters.web-root>>/themes/contrib
+          - ./<<parameters.web-root>>/profiles/contrib
+          - ./<<parameters.web-root>>/libraries
+          - ./<<parameters.web-root>>/_ping.php
         key: <<parameters.cache-version>>-dependencies-{{ checksum "composer.lock" }}-<<parameters.install-dev-dependencies>>
 
 drupal-docker-build:


### PR DESCRIPTION
Changes proposed:
- Add `web-root` parameter to `drupal-composer-install` command in case it needs to be overridden.
- Set defaults to "web" to keep workflows/configs or real projects intact.

Testing:
- https://github.com/wunderio/drupal-project-k8s/commit/de6e259bff07546ee3cd33b19354b4459cf1f09a - using command's defaults
- https://github.com/wunderio/drupal-project-k8s/commit/585ae3f60dfee3098a467f33ef60d3e7dd973845 - passing web-root param with the same value as defaults
- https://github.com/wunderio/drupal-project-k8s/commit/4caabf5e85ca3b97df0cfa6161f72192bd206a69 and https://github.com/wunderio/drupal-project-k8s/commit/06f0865f1cfde7b4975de6d25f3e26abf5a4e1e0 - overriding default value (i.e., using "docroot"). Had to make some changes to composer.lock so that caches would be re-built and "docroot" could be seen in `save_caches` output after `composer install` ran.

