### PR TITLE
Enable environment variable overriding

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -138,14 +138,8 @@ environment-variable-override:
               if [ ! -z "${!var}" ] && [ "${!var}" != "${var/${SILTA_CLUSTER_ID}_/}" ]; then
                 export ${var/${SILTA_CLUSTER_ID}_/}="${!var}"
                 echo "export ${var/${SILTA_CLUSTER_ID}_/}='${!var}'" >> "$BASH_ENV"
-
-                # set IMAGE_PULL_SECRET when GCLOUD_KEY_JSON present (and base64 encode it)
-                if [ "${var/${SILTA_CLUSTER_ID}_/}" == "GCLOUD_KEY_JSON" ]; then
-                  export IMAGE_PULL_SECRET=$(echo -n "${!var}" | base64 -w 0)
-                  echo "export IMAGE_PULL_SECRET='${IMAGE_PULL_SECRET}'" >> "$BASH_ENV"
-                fi
               fi
-            done  
+            done
           fi
 
 silta-setup:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -225,6 +225,7 @@ cloud-login:
                   -d "rbac_reload_key=${SILTA_DASHBOARD_KEY}" \
                   -d "cluster=${SILTA_CLUSTER_ID}" \
                   -d "namespace=${NAMESPACE}"
+                echo ""
                 echo "Credentials requested, please rerun the build."
               fi
               exit 1

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -125,6 +125,29 @@ docker-setup:
   steps:
     - setup_remote_docker
 
+environment-variable-override:
+  description: "Override environment variables based on cluster id."
+  steps:
+    - run:
+        name: Environment variable override
+        command: |
+          if [ ! -z "${SILTA_CLUSTER_ID}" ]; then
+            # iterate variables starting with "${SILTA_CLUSTER_ID}_"
+            for  var in $(compgen -A variable | grep "^${SILTA_CLUSTER_ID}_"); do
+              # if value is not empty and target value differs from the source value, set it as environment variable
+              if [ ! -z "${!var}" ] && [ "${!var}" != "${var/${SILTA_CLUSTER_ID}_/}" ]; then
+                export ${var/${SILTA_CLUSTER_ID}_/}="${!var}"
+                echo "export ${var/${SILTA_CLUSTER_ID}_/}='${!var}'" >> "$BASH_ENV"
+
+                # set IMAGE_PULL_SECRET when GCLOUD_KEY_JSON present (and base64 encode it)
+                if [ "${var/${SILTA_CLUSTER_ID}_/}" == "GCLOUD_KEY_JSON" ]; then
+                  export IMAGE_PULL_SECRET=$(echo -n "${!var}" | base64 -w 0)
+                  echo "export IMAGE_PULL_SECRET='${IMAGE_PULL_SECRET}'" >> "$BASH_ENV"
+                fi
+              fi
+            done  
+          fi
+
 silta-setup:
   description: "Set up silta cluster connection and set release name."
   parameters:
@@ -133,6 +156,7 @@ silta-setup:
       type: string
       default: ''
   steps:
+    - environment-variable-override
     - set-up-socks-proxy
     - cloud-login
     - docker-login


### PR DESCRIPTION
Rewrite per-cluster environment variables (`<cluster_id>_VARIABLE` used as `VARIABLE`)