### PR TITLE
set-release-name command: Use branch name or fall back to "production" if it's a tag

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -170,7 +170,8 @@ set-release-name:
         command: |
           
           NAMESPACE="${CIRCLE_PROJECT_REPONAME,,}"
-          BRANCHNAME="${CIRCLE_BRANCH}"
+          # Use branch name or fall back to "production" if it's a tag.
+          BRANCHNAME="${CIRCLE_BRANCH:-${CIRCLE_TAG:+production}}"
           
           RELEASE_NAME=$(silta ci release name --branchname "${BRANCHNAME}" --release-suffix "<<parameters.release-suffix>>")
           SILTA_ENVIRONMENT_NAME=$(silta ci release environmentname --branchname "${BRANCHNAME}" --release-suffix "<<parameters.release-suffix>>")


### PR DESCRIPTION
Let's break down this shell variable assignment: 

BRANCHNAME="${CIRCLE_BRANCH:-${CIRCLE_TAG:+production}}" 

This is using shell parameter expansion with fallback and conditional logic. Let's break it down from inside out: 

    ${CIRCLE_TAG:+production} 
        This is using the :+ operator
        If CIRCLE_TAG is set and not empty, it evaluates to "production"
        If CIRCLE_TAG is unset or empty, it evaluates to empty string
         

    ${CIRCLE_BRANCH:-...} 
        This is using the :- operator
        If CIRCLE_BRANCH is set and not empty, use its value
        If CIRCLE_BRANCH is unset or empty, use the value of what follows after :-
         
     

So putting it all together: 

    If CIRCLE_BRANCH is set:  
        BRANCHNAME = value of CIRCLE_BRANCH
         

    If CIRCLE_BRANCH is empty/unset AND CIRCLE_TAG is set: 
        BRANCHNAME = "production"
         

    If both CIRCLE_BRANCH and CIRCLE_TAG are empty/unset: 
        BRANCHNAME = empty string
         
     