### PR TITLE
Do not require dockerignore files

### DIFF
--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -61,6 +61,30 @@ drupal-validate:
         install-dev-dependencies: true
     - phpcs
     - grumphp
+    - run:
+        name: Silta basic checks
+        command: |
+          files=(
+            silta/silta.yml
+            silta/silta-prod.yml
+            silta/nginx.Dockerfile
+            silta/php.Dockerfile
+            silta/shell.Dockerfile
+          )
+
+          for file in "${files[@]}"; do
+            if [ -f "$file" ]; then
+              echo "✅ $file is present"
+            else
+              echo "❌ $file is missing from the repository."
+              exit 1
+            fi
+          done
+
+          if grep "drush.*8" composer.json; then
+            echo "❌ Silta is not compatible with drush 8."
+          fi
+
     - steps: <<parameters.post-validation>>
 
 drupal-build-deploy: &drupal-build-deploy

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -61,32 +61,6 @@ drupal-validate:
         install-dev-dependencies: true
     - phpcs
     - grumphp
-    - run:
-        name: Silta basic checks
-        command: |
-          files=(
-            silta/silta.yml
-            silta/silta-prod.yml
-            silta/nginx.Dockerfile
-            silta/php.Dockerfile
-            silta/shell.Dockerfile
-            .dockerignore
-            <<parameters.web-root>>/.dockerignore
-          )
-
-          for file in "${files[@]}"; do
-            if [ -f "$file" ]; then
-              echo "✅ $file is present"
-            else
-              echo "❌ $file is missing from the repository."
-              exit 1
-            fi
-          done
-
-          if grep "drush.*8" composer.json; then
-            echo "❌ Silta is not compatible with drush 8."
-          fi
-
     - steps: <<parameters.post-validation>>
 
 drupal-build-deploy: &drupal-build-deploy


### PR DESCRIPTION
We're moving .dockerignore to Dockerfile-specific ignore-file (`<dockerfile>.dockerignore`) so the old files might not be present for new projects, but missing for the new ones. Dockerignore files are not mandatory for build process anymore.

I'd propose removal of all file checks as projects are using templates and silta.yml file is only mandatory when not overriden, but i'll just remove dockerignore checks at this time. 