### PR TITLE
Custom proxy command

### DIFF
--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -152,7 +152,6 @@ silta-setup:
     custom-command:
       description: "Custom command to execute for setting up a proxy."
       type: string
-      default: ''
   steps:
     - environment-variable-override
     - set-up-socks-proxy:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -149,13 +149,9 @@ silta-setup:
       description: "Release name suffix."
       type: string
       default: ''
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
   steps:
     - environment-variable-override
-    - set-up-socks-proxy:
-        custom-command: '<<parameters.custom-command>>'
+    - set-up-socks-proxy
     - cloud-login
     - docker-login
     - set-release-name:
@@ -280,30 +276,6 @@ decrypt-files:
 
 set-up-socks-proxy:
   description: "Set up socks proxy for outgoing connections."
-  parameters:
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
-      default: |
-          if [[ -n "$TUNNEL_USER_HOST" ]]; then
-            ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
-            echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
-            if command -v gcloud &> /dev/null; then
-              gcloud config set proxy/type socks5
-              gcloud config set proxy/address 127.0.0.1
-              gcloud config set proxy/port 1337
-            fi
-            if command -v silta &> /dev/null; then
-              if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
-                pproxy -r socks5://127.0.0.1:1337 --daemon
-                silta config set proxy http://localhost:8080
-              else
-                silta config set proxy socks5://localhost:1337
-              fi
-            fi
-            echo "Proxy is ready for outgoing connections"
-          fi
-
   steps:
     - run:
         name: Add SSH private-key
@@ -313,8 +285,31 @@ set-up-socks-proxy:
           fi
     - run:
         name: Proxy setup for cluster connections
+        # command: |
+          # <<parameters.custom-command>>
         command: |
-          <<parameters.custom-command>>
+          if [[ -n "<<pipeline.parameters.custom-command>>" ]]; then
+            echo "pipeline test"
+          else
+            if [[ -n "$TUNNEL_USER_HOST" ]]; then
+              ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
+              echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
+              if command -v gcloud &> /dev/null; then
+                gcloud config set proxy/type socks5
+                gcloud config set proxy/address 127.0.0.1
+                gcloud config set proxy/port 1337
+              fi
+              if command -v silta &> /dev/null; then
+                if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
+                  pproxy -r socks5://127.0.0.1:1337 --daemon
+                  silta config set proxy http://localhost:8080
+                else
+                  silta config set proxy socks5://localhost:1337
+                fi
+              fi
+              echo "Proxy is ready for outgoing connections"
+            fi
+          fi
 
 extend-helm-chart:
   description: "Add additional Helm charts"

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -149,9 +149,14 @@ silta-setup:
       description: "Release name suffix."
       type: string
       default: ''
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   steps:
     - environment-variable-override
-    - set-up-socks-proxy
+    - set-up-socks-proxy:
+        custom-command: '<<parameters.custom-command>>'
     - cloud-login
     - docker-login
     - set-release-name:
@@ -276,6 +281,11 @@ decrypt-files:
 
 set-up-socks-proxy:
   description: "Set up socks proxy for outgoing connections."
+  parameters:
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   steps:
     - run:
         name: Add SSH private-key
@@ -284,14 +294,14 @@ set-up-socks-proxy:
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
           fi
     - when:
-        condition: << pipeline.parameters.custom-command >>
+        condition: <<parameters.custom-command>>
         steps:
           - run:
               name: Proxy setup for cluster connections
               command: |
-                echo "pipeline test"
+                <<parameters.custom-command>>
     - unless:
-        condition: << pipeline.parameters.custom-command >>
+        condition: <<parameters.custom-command>>
         steps:
           - run:
               name: Proxy setup for cluster connections

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -149,14 +149,14 @@ silta-setup:
       description: "Release name suffix."
       type: string
       default: ''
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
   steps:
     - environment-variable-override
     - set-up-socks-proxy:
-        custom-command: '<<parameters.custom-command>>'
+        custom-proxy-command: '<<parameters.custom-proxy-command>>'
     - cloud-login
     - docker-login
     - set-release-name:
@@ -282,7 +282,7 @@ decrypt-files:
 set-up-socks-proxy:
   description: "Set up socks proxy for outgoing connections."
   parameters:
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
@@ -294,14 +294,14 @@ set-up-socks-proxy:
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
           fi
     - when:
-        condition: <<parameters.custom-command>>
+        condition: <<parameters.custom-proxy-command>>
         steps:
           - run:
               name: Proxy setup for cluster connections
               command: |
-                <<parameters.custom-command>>
+                <<parameters.custom-proxy-command>>
     - unless:
-        condition: <<parameters.custom-command>>
+        condition: <<parameters.custom-proxy-command>>
         steps:
           - run:
               name: Proxy setup for cluster connections

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -286,33 +286,33 @@ set-up-socks-proxy:
     - when:
       condition: << pipeline.parameters.custom-command >>
       steps:
-      - run:
-          name: Proxy setup for cluster connections
-          # command: |
-            # <<parameters.custom-command>>
-          command: |
-            if [[ -n "<<pipeline.parameters.custom-command>>" ]]; then
-              echo "pipeline test"
-            else
-              if [[ -n "$TUNNEL_USER_HOST" ]]; then
-                ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
-                echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
-                if command -v gcloud &> /dev/null; then
-                  gcloud config set proxy/type socks5
-                  gcloud config set proxy/address 127.0.0.1
-                  gcloud config set proxy/port 1337
-                fi
-                if command -v silta &> /dev/null; then
-                  if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
-                    pproxy -r socks5://127.0.0.1:1337 --daemon
-                    silta config set proxy http://localhost:8080
-                  else
-                    silta config set proxy socks5://localhost:1337
+        - run:
+            name: Proxy setup for cluster connections
+            # command: |
+              # <<parameters.custom-command>>
+            command: |
+              if [[ -n "<<pipeline.parameters.custom-command>>" ]]; then
+                echo "pipeline test"
+              else
+                if [[ -n "$TUNNEL_USER_HOST" ]]; then
+                  ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
+                  echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
+                  if command -v gcloud &> /dev/null; then
+                    gcloud config set proxy/type socks5
+                    gcloud config set proxy/address 127.0.0.1
+                    gcloud config set proxy/port 1337
                   fi
+                  if command -v silta &> /dev/null; then
+                    if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
+                      pproxy -r socks5://127.0.0.1:1337 --daemon
+                      silta config set proxy http://localhost:8080
+                    else
+                      silta config set proxy socks5://localhost:1337
+                    fi
+                  fi
+                  echo "Proxy is ready for outgoing connections"
                 fi
-                echo "Proxy is ready for outgoing connections"
               fi
-            fi
 
 extend-helm-chart:
   description: "Add additional Helm charts"

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -284,16 +284,18 @@ set-up-socks-proxy:
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
           fi
     - when:
-      condition: << pipeline.parameters.custom-command >>
-      steps:
-        - run:
-            name: Proxy setup for cluster connections
-            # command: |
-              # <<parameters.custom-command>>
-            command: |
-              if [[ -n "<<pipeline.parameters.custom-command>>" ]]; then
+        condition: << pipeline.parameters.custom-command >>
+        steps:
+          - run:
+              name: Proxy setup for cluster connections
+              command: |
                 echo "pipeline test"
-              else
+    - unless:
+        condition: << pipeline.parameters.custom-command >>
+        steps:
+          - run:
+              name: Proxy setup for cluster connections
+              command: |
                 if [[ -n "$TUNNEL_USER_HOST" ]]; then
                   ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
                   echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
@@ -312,7 +314,6 @@ set-up-socks-proxy:
                   fi
                   echo "Proxy is ready for outgoing connections"
                 fi
-              fi
 
 extend-helm-chart:
   description: "Add additional Helm charts"

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -276,16 +276,11 @@ decrypt-files:
 
 set-up-socks-proxy:
   description: "Set up socks proxy for outgoing connections."
-  steps:
-    - run:
-        name: Add SSH private-key
-        command: |
-          if [[ -n "$TUNNEL_PRIVATE_KEY" ]]; then
-            echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
-          fi
-    - run:
-        name: Proxy setup for cluster connections
-        command: |
+  parameters:
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: |
           if [[ -n "$TUNNEL_USER_HOST" ]]; then
             ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
             echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
@@ -304,6 +299,18 @@ set-up-socks-proxy:
             fi
             echo "Proxy is ready for outgoing connections"
           fi
+
+  steps:
+    - run:
+        name: Add SSH private-key
+        command: |
+          if [[ -n "$TUNNEL_PRIVATE_KEY" ]]; then
+            echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
+          fi
+    - run:
+        name: Proxy setup for cluster connections
+        command: |
+          <<parameters.custom-command>>
 
 extend-helm-chart:
   description: "Add additional Helm charts"

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -149,9 +149,14 @@ silta-setup:
       description: "Release name suffix."
       type: string
       default: ''
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: ''
   steps:
     - environment-variable-override
-    - set-up-socks-proxy
+    - set-up-socks-proxy:
+        custom-command: '<<parameters.custom-command>>'
     - cloud-login
     - docker-login
     - set-release-name:

--- a/orb/commands/@common.yml
+++ b/orb/commands/@common.yml
@@ -283,33 +283,36 @@ set-up-socks-proxy:
           if [[ -n "$TUNNEL_PRIVATE_KEY" ]]; then
             echo -e "$TUNNEL_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
           fi
-    - run:
-        name: Proxy setup for cluster connections
-        # command: |
-          # <<parameters.custom-command>>
-        command: |
-          if [[ -n "<<pipeline.parameters.custom-command>>" ]]; then
-            echo "pipeline test"
-          else
-            if [[ -n "$TUNNEL_USER_HOST" ]]; then
-              ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
-              echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
-              if command -v gcloud &> /dev/null; then
-                gcloud config set proxy/type socks5
-                gcloud config set proxy/address 127.0.0.1
-                gcloud config set proxy/port 1337
-              fi
-              if command -v silta &> /dev/null; then
-                if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
-                  pproxy -r socks5://127.0.0.1:1337 --daemon
-                  silta config set proxy http://localhost:8080
-                else
-                  silta config set proxy socks5://localhost:1337
+    - when:
+      condition: << pipeline.parameters.custom-command >>
+      steps:
+      - run:
+          name: Proxy setup for cluster connections
+          # command: |
+            # <<parameters.custom-command>>
+          command: |
+            if [[ -n "<<pipeline.parameters.custom-command>>" ]]; then
+              echo "pipeline test"
+            else
+              if [[ -n "$TUNNEL_USER_HOST" ]]; then
+                ssh -o StrictHostKeyChecking=accept-new -D 1337 -C -N -q -f "$TUNNEL_USER_HOST"
+                echo 'export SILTA_PROXY=socks5://localhost:1337' >> $BASH_ENV
+                if command -v gcloud &> /dev/null; then
+                  gcloud config set proxy/type socks5
+                  gcloud config set proxy/address 127.0.0.1
+                  gcloud config set proxy/port 1337
                 fi
+                if command -v silta &> /dev/null; then
+                  if [ "$CLUSTER_TYPE" == "aws" ] && command -v pproxy &> /dev/null; then
+                    pproxy -r socks5://127.0.0.1:1337 --daemon
+                    silta config set proxy http://localhost:8080
+                  else
+                    silta config set proxy socks5://localhost:1337
+                  fi
+                fi
+                echo "Proxy is ready for outgoing connections"
               fi
-              echo "Proxy is ready for outgoing connections"
             fi
-          fi
 
 extend-helm-chart:
   description: "Add additional Helm charts"

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -173,6 +173,10 @@ drupal-build-deploy: &drupal-build-deploy
       description: "Extension config for the source chart"
       type: string
       default: ''
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -194,6 +198,7 @@ drupal-build-deploy: &drupal-build-deploy
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
+              custom-command: '<<parameters.custom-command>>'
           - extend-helm-chart:
               source_chart: '<<parameters.source_chart>>'
               extension_file: '<<parameters.extension_file>>'
@@ -287,6 +292,10 @@ drupal-build:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -305,6 +314,7 @@ drupal-build:
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
+              custom-command: '<<parameters.custom-command>>'
           - drupal-docker-build:
               nginx_build_context: <<parameters.nginx_build_context>>
               background: <<parameters.image_build_background>>
@@ -394,6 +404,10 @@ drupal-deploy: &drupal-deploy
       type: enum
       enum: ["latest", "test"]
       default: "latest"
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -414,6 +428,7 @@ drupal-deploy: &drupal-deploy
                     files: <<parameters.decrypt_files>>
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
+              custom-command: '<<parameters.custom-command>>'
           - steps: <<parameters.pre-release>>
           - attach_workspace:
               at: /tmp/workspace

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -173,6 +173,10 @@ drupal-build-deploy: &drupal-build-deploy
       description: "Extension config for the source chart"
       type: string
       default: ''
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -194,6 +198,7 @@ drupal-build-deploy: &drupal-build-deploy
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
+              custom-command: '<<parameters.custom-command>>'
           - extend-helm-chart:
               source_chart: '<<parameters.source_chart>>'
               extension_file: '<<parameters.extension_file>>'
@@ -287,6 +292,10 @@ drupal-build:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -305,6 +314,7 @@ drupal-build:
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
+              custom-command: '<<parameters.custom-command>>'
           - drupal-docker-build:
               nginx_build_context: <<parameters.nginx_build_context>>
               background: <<parameters.image_build_background>>
@@ -394,6 +404,10 @@ drupal-deploy: &drupal-deploy
       type: enum
       enum: ["latest", "test"]
       default: "latest"
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -414,6 +428,7 @@ drupal-deploy: &drupal-deploy
                     files: <<parameters.decrypt_files>>
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
+              custom-command: '<<parameters.custom-command>>'
           - steps: <<parameters.pre-release>>
           - attach_workspace:
               at: /tmp/workspace

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -173,9 +173,6 @@ drupal-build-deploy: &drupal-build-deploy
       description: "Extension config for the source chart"
       type: string
       default: ''
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -197,7 +194,6 @@ drupal-build-deploy: &drupal-build-deploy
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
-              custom-command: '<<parameters.custom-command>>'
           - extend-helm-chart:
               source_chart: '<<parameters.source_chart>>'
               extension_file: '<<parameters.extension_file>>'
@@ -291,9 +287,6 @@ drupal-build:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -312,7 +305,6 @@ drupal-build:
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
-              custom-command: '<<parameters.custom-command>>'
           - drupal-docker-build:
               nginx_build_context: <<parameters.nginx_build_context>>
               background: <<parameters.image_build_background>>
@@ -402,9 +394,6 @@ drupal-deploy: &drupal-deploy
       type: enum
       enum: ["latest", "test"]
       default: "latest"
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -425,7 +414,6 @@ drupal-deploy: &drupal-deploy
                     files: <<parameters.decrypt_files>>
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
-              custom-command: '<<parameters.custom-command>>'
           - steps: <<parameters.pre-release>>
           - attach_workspace:
               at: /tmp/workspace

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -173,7 +173,7 @@ drupal-build-deploy: &drupal-build-deploy
       description: "Extension config for the source chart"
       type: string
       default: ''
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
@@ -198,7 +198,7 @@ drupal-build-deploy: &drupal-build-deploy
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
-              custom-command: '<<parameters.custom-command>>'
+              custom-proxy-command: '<<parameters.custom-proxy-command>>'
           - extend-helm-chart:
               source_chart: '<<parameters.source_chart>>'
               extension_file: '<<parameters.extension_file>>'
@@ -292,7 +292,7 @@ drupal-build:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
@@ -314,7 +314,7 @@ drupal-build:
           - docker-setup
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
-              custom-command: '<<parameters.custom-command>>'
+              custom-proxy-command: '<<parameters.custom-proxy-command>>'
           - drupal-docker-build:
               nginx_build_context: <<parameters.nginx_build_context>>
               background: <<parameters.image_build_background>>
@@ -404,7 +404,7 @@ drupal-deploy: &drupal-deploy
       type: enum
       enum: ["latest", "test"]
       default: "latest"
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
@@ -428,7 +428,7 @@ drupal-deploy: &drupal-deploy
                     files: <<parameters.decrypt_files>>
           - silta-setup:
               release-suffix: '<<parameters.release-suffix>>'
-              custom-command: '<<parameters.custom-command>>'
+              custom-proxy-command: '<<parameters.custom-proxy-command>>'
           - steps: <<parameters.pre-release>>
           - attach_workspace:
               at: /tmp/workspace

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -176,7 +176,6 @@ drupal-build-deploy: &drupal-build-deploy
     custom-command:
       description: "Custom command to execute for setting up a proxy."
       type: string
-      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -295,7 +294,6 @@ drupal-build:
     custom-command:
       description: "Custom command to execute for setting up a proxy."
       type: string
-      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -407,7 +405,6 @@ drupal-deploy: &drupal-deploy
     custom-command:
       description: "Custom command to execute for setting up a proxy."
       type: string
-      default: ''
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -66,6 +66,10 @@ frontend-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   steps:
     - checkout
     - silta-cli-setup:
@@ -76,6 +80,7 @@ frontend-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
+        custom-command: '<<parameters.custom-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -66,6 +66,10 @@ frontend-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: ''
   steps:
     - checkout
     - silta-cli-setup:
@@ -76,6 +80,7 @@ frontend-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
+        custom-command: '<<parameters.custom-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -66,9 +66,6 @@ frontend-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
   steps:
     - checkout
     - silta-cli-setup:
@@ -79,7 +76,6 @@ frontend-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
-        custom-command: '<<parameters.custom-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -69,7 +69,6 @@ frontend-build-deploy:
     custom-command:
       description: "Custom command to execute for setting up a proxy."
       type: string
-      default: ''
   steps:
     - checkout
     - silta-cli-setup:

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -66,7 +66,7 @@ frontend-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
@@ -80,7 +80,7 @@ frontend-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
-        custom-command: '<<parameters.custom-command>>'
+        custom-proxy-command: '<<parameters.custom-proxy-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -69,6 +69,10 @@ simple-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
+    custom-command:
+      description: "Custom command to execute for setting up a proxy."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:
@@ -82,6 +86,7 @@ simple-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
+        custom-command: '<<parameters.custom-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -69,9 +69,6 @@ simple-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
-    custom-command:
-      description: "Custom command to execute for setting up a proxy."
-      type: string
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:
@@ -85,7 +82,6 @@ simple-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
-        custom-command: '<<parameters.custom-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -72,7 +72,6 @@ simple-build-deploy:
     custom-command:
       description: "Custom command to execute for setting up a proxy."
       type: string
-      default: ''
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -69,6 +69,10 @@ simple-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
+    custom-command:
+      description: "Custom command to run instead of the default proxy setup."
+      type: string
+      default: ''
   working_directory: ~/project/<<parameters.codebase_root>>
   steps:
     - checkout:
@@ -82,6 +86,7 @@ simple-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
+        custom-command: '<<parameters.custom-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'

--- a/orb/jobs/@simple.yml
+++ b/orb/jobs/@simple.yml
@@ -69,7 +69,7 @@ simple-build-deploy:
       type: enum
       enum: [ "latest", "test" ]
       default: "latest"
-    custom-command:
+    custom-proxy-command:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
@@ -86,7 +86,7 @@ simple-build-deploy:
     - docker-setup
     - silta-setup:
         release-suffix: '<<parameters.release-suffix>>'
-        custom-command: '<<parameters.custom-command>>'
+        custom-proxy-command: '<<parameters.custom-proxy-command>>'
 
     - extend-helm-chart:
         source_chart: '<<parameters.source_chart>>'


### PR DESCRIPTION
### Description
Gives users ability to define their own commands for setting up proxy connections. Do note that "Add SSH private-key" still runs before these commands.

### Testing
1. For a drupal-project-k8s/simple-project-k8s/frontend-project-k8s deploy job, add a `custom-proxy-command` key with a command to execute, for example:
```
custom-proxy-command: |
  echo "Testing"
```
2. If present, leave build job alone.

3. During deployment, build job should execute default commands for "Proxy setup for cluster connections" step. Deploy job should execute command defined in step 2.