### PR TITLE
SLT-1167: Make helm flags configurable

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -151,6 +151,10 @@ drupal-helm-deploy:
     deployment_timeout:
       type: string
       default: "15m"
+    helm_flags:
+      description: "Custom helm flags to add to the helm deploy command."
+      type: string
+      default: ""
   steps:
     - helm-cleanup
     - run:
@@ -185,6 +189,7 @@ drupal-helm-deploy:
             --db-root-pass "${DB_ROOT_PASS}" \
             --db-user-pass "${DB_USER_PASS}" \
             --namespace "${NAMESPACE}" \
+            --helm-flags "<<parameters.helm_flags>>" \
             --silta-config "<<parameters.silta_config>>" \
             --deployment-timeout "<<parameters.deployment_timeout>>"
 

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -408,6 +408,10 @@ drupal-deploy: &drupal-deploy
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
+    helm_flags:
+      description: "Custom helm flags to add to the helm deploy command."
+      type: string
+      default: ""
   working_directory: ~/project/<<parameters.drupal-root>>
   steps:
     - checkout:
@@ -455,6 +459,7 @@ drupal-deploy: &drupal-deploy
               silta_config: <<parameters.silta_config>>
               cluster_domain: <<parameters.cluster_domain>>
               deployment_timeout: <<parameters.deployment_timeout>>
+              helm_flags: <<parameters.helm_flags>>
 
 # Job to deploy using development charts. This extends the
 # drupal-deploy job and overrides some of the parameters.

--- a/orb/jobs/@frontend.yml
+++ b/orb/jobs/@frontend.yml
@@ -70,6 +70,10 @@ frontend-build-deploy:
       description: "Custom command to run instead of the default proxy setup."
       type: string
       default: ''
+    helm_flags:
+      description: "Custom helm flags to add to the helm deploy command."
+      type: string
+      default: ""
   steps:
     - checkout
     - silta-cli-setup:
@@ -127,6 +131,6 @@ frontend-build-deploy:
                   --vpc-native "${VPC_NATIVE}" \
                   --cluster-type "${CLUSTER_TYPE}" \
                   --silta-config "<<parameters.silta_config>>" \
-                  --helm-flags "${image_overrides}"
+                  --helm-flags "<<parameters.helm_flags>> ${image_overrides}"
 
           - helm-release-information


### PR DESCRIPTION
https://wunder.atlassian.net/browse/SLT-1167

This pull request introduces a new `helm_flags` parameter across multiple commands and jobs in the `orb` configuration files. This parameter allows users to pass custom Helm flags to the Helm deploy command, enhancing flexibility during deployments.

### Additions of the `helm_flags` Parameter:

#### Changes in `drupal-helm-deploy:` (`orb/commands/@drupal.yml`)
* Added a new `helm_flags` parameter to accept custom Helm flags, with a default value of an empty string.
* Updated the Helm deploy command to include the `helm_flags` parameter.

#### Changes in `drupal-deploy:` (`orb/jobs/@drupal.yml`)
* Introduced the `helm_flags` parameter to the job configuration, allowing custom Helm flags to be specified.
* Passed the `helm_flags` parameter to the `drupal-helm-deploy` command.

#### Changes in `frontend-build-deploy:` (`orb/jobs/@frontend.yml`)
* Added the `helm_flags` parameter to the job configuration.
* Modified the Helm deploy command to append the `helm_flags` parameter alongside existing image overrides.

### Tests
* Tested in [drupal-project-k8s](https://app.circleci.com/pipelines/github/wunderio/drupal-project-k8s?branch=feature%2Ftest-helm-flags), here are screenshots before and after adding `helm_flags: "--history-max=2"`
![Monosnap k9s 2025-05-09 14-01-43](https://github.com/user-attachments/assets/a6722acd-8158-4e10-b56c-d8350c273a4e)
![Monosnap k9s 2025-05-09 14-11-22](https://github.com/user-attachments/assets/971dd732-740a-407c-adef-7d19c9d4027b)



* Tested in [frontend-project-k8s](https://app.circleci.com/pipelines/github/wunderio/frontend-project-k8s?branch=feature%2Ftest-helm-flags), , here are screenshots before and after adding `helm_flags: "--history-max=2"`
![Monosnap k9s 2025-05-09 14-31-45](https://github.com/user-attachments/assets/5a95afe2-6a67-41d7-b586-9e8cea9ffb18)
![Monosnap k9s 2025-05-09 14-43-29](https://github.com/user-attachments/assets/5a7ad557-f2cd-4c34-b84a-d0a63c92734a)
