### PR TITLE
SLT-1221: Introduce drupal-silta-verify

### DIFF
--- a/orb/commands/@drupal.yml
+++ b/orb/commands/@drupal.yml
@@ -18,6 +18,33 @@ grumphp:
             vendor/bin/grumphp run
           fi
 
+drupal-silta-verify:
+  description: "Verify Silta configuration files"
+  steps:
+    - run:
+        name: Silta basic checks
+        command: |
+          files=(
+            silta/silta.yml
+            silta/silta-prod.yml
+            silta/nginx.Dockerfile
+            silta/php.Dockerfile
+            silta/shell.Dockerfile
+          )
+
+          for file in "${files[@]}"; do
+            if [ -f "$file" ]; then
+              echo "✅ $file is present"
+            else
+              echo "❌ $file is missing from the repository."
+              exit 1
+            fi
+          done
+
+          if grep "drush.*8" composer.json; then
+            echo "❌ Silta is not compatible with drush 8."
+          fi
+
 drupal-composer-install:
   description: "PHP composer install command."
   parameters:

--- a/orb/jobs/@drupal.yml
+++ b/orb/jobs/@drupal.yml
@@ -61,29 +61,7 @@ drupal-validate:
         install-dev-dependencies: true
     - phpcs
     - grumphp
-    - run:
-        name: Silta basic checks
-        command: |
-          files=(
-            silta/silta.yml
-            silta/silta-prod.yml
-            silta/nginx.Dockerfile
-            silta/php.Dockerfile
-            silta/shell.Dockerfile
-          )
-
-          for file in "${files[@]}"; do
-            if [ -f "$file" ]; then
-              echo "✅ $file is present"
-            else
-              echo "❌ $file is missing from the repository."
-              exit 1
-            fi
-          done
-
-          if grep "drush.*8" composer.json; then
-            echo "❌ Silta is not compatible with drush 8."
-          fi
+    - drupal-silta-verify
 
     - steps: <<parameters.post-validation>>
 


### PR DESCRIPTION
[SLT-1221](https://wunder.atlassian.net/browse/SLT-1221)

There was raised concerncs on overriding `drupal-validate` jobs that it becomes messy ( see. [.circleci/config.yml](https://github.com/wunderio/client-fi-foli-cms/pull/813/commits/8d22aacf72077c0f43e8dc402ec2c58b8c32441c),
[client-fi-foli-cms/pull/813](https://github.com/wunderio/client-fi-foli-cms/pull/813/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R48) ).

This PR Introduce new command for "Silta basic checks" so it can be easily re-used in overridden validation processes

Tested on [feature/FSD-344-test](https://app.circleci.com/pipelines/github/wunderio/client-fi-foli-cms/1870/workflows/bb63ccaf-a961-4ec6-acc6-3d8cfad10464/jobs/4178?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)

[SLT-1221]: https://wunder.atlassian.net/browse/SLT-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ